### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -137,7 +137,9 @@ def _check_link_logic(page, url):
             title_text = page.title().lower()
             has_404_keywords = False
             is_codewiki = "codewiki.google" in page.url
-            is_github = "github.com" in page.url
+            parsed_page_url = urlparse(page.url)
+            page_host = (parsed_page_url.hostname or "").lower()
+            is_github = page_host == "github.com" or page_host.endswith(".github.com")
             
             if is_codewiki:
                 # CodeWiki specific check


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/tool-survey-report/security/code-scanning/12](https://github.com/aegisfleet/tool-survey-report/security/code-scanning/12)

Use `urlparse(page.url).hostname` and compare the parsed hostname against allowed GitHub host patterns.  
Best fix here (without changing intended behavior) is to:

- Keep existing `is_codewiki` check as-is (not flagged).
- Replace line 140 substring logic with hostname-based matching:
  - Parse `page.url`.
  - Normalize hostname to lowercase.
  - Treat as GitHub only when hostname is exactly `github.com` or ends with `.github.com`.

This avoids accidental matches in path/query and avoids matching lookalike hosts such as `evilgithub.com`.

Edit region: `scripts/check_links.py`, inside `_check_link_logic`, around current lines 139–141.

No new imports are needed (`urlparse` is already imported on line 8).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * GitHub リンクの検出ロジックを改善し、リンク検証の精度を向上させました。ホスト名ベースのマッチングにより、GitHub 固有の 404 エラー判定がより正確になります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->