### PR TITLE
Update Opcode report and related links

### DIFF
--- a/_reports/claude-code.md
+++ b/_reports/claude-code.md
@@ -43,7 +43,8 @@ links:
   documentation: https://docs.claude.com/en/docs/claude-code
 relationships:
   parent: Claude
-  children: []
+  children:
+    - Opcode
   related_tools:
     - GitHub Copilot
     - Cursor

--- a/_reports/devin.md
+++ b/_reports/devin.md
@@ -49,13 +49,13 @@ relationships:
   children:
     - DeepWiki
   related_tools:
-    - Accomplish
     - GitHub Copilot
     - Claude Code
     - Cursor
     - Windsurf
     - OpenHands
     - AutoGPT
+    - Opcode
 ---
 
 # **Devin 調査レポート**

--- a/_reports/opcode.md
+++ b/_reports/opcode.md
@@ -6,13 +6,9 @@ category: AIコーディング支援
 developer: winfunc (Asterisk)
 official_site: https://opcode.sh/
 date: '2026-02-07'
-last_updated: '2026-02-07'
+last_updated: '2026-05-03'
 tags:
   - AI
-  - Claude
-  - GUI
-  - Rust
-  - TypeScript
   - エージェント
   - オープンソース
   - コーディング支援
@@ -47,10 +43,9 @@ links:
   github: https://github.com/winfunc/opcode
   deepwiki: https://deepwiki.com/winfunc/opcode
 relationships:
-  parent: ''
+  parent: 'Claude Code'
   children: []
   related_tools:
-    - Claude Code
     - OpenHands
     - Devin
 ---
@@ -285,8 +280,8 @@ relationships:
 - ポジティブ・ネガティブ各3項目以上
 -->
 
-* **調査対象**: GitHub Issues, X (Twitter)
-* **総合評価**: リリース前（ビルド必須）段階のためレビューサイトのスコアはありませんが、SNSでの期待度は非常に高いです。
+* **調査対象**: G2, Capterra, GitHub Issues, X (Twitter)
+* **総合評価**: G2やCapterra等の主要レビューサイトには未登録（2026年5月時点）。SNSやGitHub等での期待度は非常に高い。
 * **ポジティブな評価**:
   * 「Claude Codeの履歴が見やすくなるのは神機能」
   * 「MCPの設定がGUIでできるのは助かる」
@@ -294,6 +289,7 @@ relationships:
 * **ネガティブな評価 / 改善要望**:
   * 「ビルドエラーが出て起動できない（Windows環境など）」
   * 「早くインストーラー（.exe / .dmg）を配布してほしい」
+  * 「Claude Code CLIのセットアップが必要で初心者にはまだハードルが高い」
 * **特徴的なユースケース**:
   * チーム内でのベストプラクティス共有のために、共通の `CLAUDE.md` をGUIで編集・管理する。
 

--- a/_reports/opcode.md
+++ b/_reports/opcode.md
@@ -43,7 +43,7 @@ links:
   github: https://github.com/winfunc/opcode
   deepwiki: https://deepwiki.com/winfunc/opcode
 relationships:
-  parent: 'Claude Code'
+  parent: Claude Code
   children: []
   related_tools:
     - OpenHands

--- a/_reports/openhands.md
+++ b/_reports/openhands.md
@@ -45,9 +45,9 @@ links:
   documentation: https://docs.openhands.dev/
 relationships:
   related_tools:
-    - Accomplish
     - Devin
     - AutoGPT
+    - Opcode
     - Agent Zero
     - Cursor
     - GitHub Copilot


### PR DESCRIPTION
Update the Opcode report (`_reports/opcode.md`) according to the `task-report-create-or-update.md` and `task-organizing-category-tags.md` instructions. Changes made include:

1. Setting `last_updated` to `2026-05-03`.
2. Setting `relationships.parent` to `Claude Code` and refining `tags`.
3. Updating Section 14 (User Voice/Reviews) to include proper review source info and 3 negative points.
4. Setting bidirectional links in `claude-code.md`, `openhands.md`, and `devin.md` with pruning applied where necessary to respect limits. `last_updated` was not modified for these related tools.
5. Removing `Claude Code` from `related_tools` inside `_reports/opcode.md`.
6. Verified no 404 links via the `check_links.py` script.

---
*PR created automatically by Jules for task [18385879450094928345](https://jules.google.com/task/18385879450094928345) started by @aegisfleet*