### PR TITLE
Update Dify pronunciation to 'ディフィー'

### DIFF
--- a/_reports/dify.md
+++ b/_reports/dify.md
@@ -1,7 +1,7 @@
 ---
 title: Dify 調査レポート
 tool_name: Dify
-tool_reading: ディファイ
+tool_reading: ディフィー
 category: 🛠️ AIエージェント基盤
 developer: LangGenius, Inc.
 official_site: https://dify.ai/
@@ -74,7 +74,7 @@ relationships:
 -->
 
 * **ツール名**: Dify
-* **ツールの読み方**: ディファイ
+* **ツールの読み方**: ディフィー
 * **開発元**: LangGenius, Inc.
 * **公式サイト**: [https://dify.ai/](https://dify.ai/)
 * **関連リンク**:


### PR DESCRIPTION
This commit updates the documented Japanese pronunciation of Dify from "ディファイ" to "ディフィー" in `_reports/dify.md`, following an official brand update announcement from the Dify team.

Specifically, it updates:
1. The `tool_reading` field in the frontmatter.
2. The "ツールの読み方" field in the body of the report.

---
*PR created automatically by Jules for task [6667781829530513455](https://jules.google.com/task/6667781829530513455) started by @aegisfleet*