### PR TITLE
chore: organize report categories and tags (2026-05-30)

### DIFF
--- a/_reports/gordon.md
+++ b/_reports/gordon.md
@@ -2,16 +2,17 @@
 title: Docker Gordon 調査レポート
 tool_name: Gordon
 tool_reading: ゴードン
-category: AIアシスタント
+category: AIコーディング支援
 developer: Docker Inc.
 official_site: https://www.docker.com/products/gordon/
 date: '2026-05-29'
 last_updated: '2026-05-29'
 tags:
-  - Docker
-  - コンテナ
   - AI
+  - エージェント
   - 開発者ツール
+  - コンテナ
+  - Docker
 description: Docker環境に特化し、コンテナのデバッグやDockerfile生成などのタスクを支援するAIエージェント。
 quick_summary:
   has_free_plan: true

--- a/_reports/microsoft-defender-for-cloud.md
+++ b/_reports/microsoft-defender-for-cloud.md
@@ -2,17 +2,17 @@
 title: Microsoft Defender for Cloud 調査レポート
 tool_name: Microsoft Defender for Cloud
 tool_reading: マイクロソフト ディフェンダー フォー クラウド
-category: セキュリティ
+category: セキュリティ/解析
 developer: Microsoft
 official_site: https://azure.microsoft.com/ja-jp/products/defender-for-cloud/
 date: '2026-05-28'
 last_updated: '2026-05-28'
 tags:
-  - クラウドセキュリティ
+  - クラウド
+  - セキュリティ
   - CSPM
   - CWPP
   - DevSecOps
-  - CNAPP
 description: Azure、AWS、Google Cloudなどのマルチクラウドおよびハイブリッド環境全体を保護する、統合型のクラウドネイティブアプリケーション保護プラットフォーム (CNAPP)。
 quick_summary:
   has_free_plan: true


### PR DESCRIPTION
- `gordon.md` のカテゴリを「AIアシスタント」から「AIコーディング支援」へ統合し、必須・推奨タグへ修正しました。
- `microsoft-defender-for-cloud.md` のカテゴリを「セキュリティ」から「セキュリティ/解析」へ統合し、タグを標準語彙に修正しました。
- 10件以上のカテゴリ分割については、細分化しすぎによる検索性低下を防ぐため、現状維持としています。
- リレーションシップには意図しない副作用や破壊的変更（存在しないツールのslug等）がないよう、変更を控えています。

---
*PR created automatically by Jules for task [8277180967307101239](https://jules.google.com/task/8277180967307101239) started by @aegisfleet*