### PR TITLE
Update RTK report with the latest release details

### DIFF
--- a/_reports/rtk.md
+++ b/_reports/rtk.md
@@ -6,7 +6,7 @@ category: 開発ユーティリティ
 developer: Patrick Szymkowiak
 official_site: https://www.rtk-ai.app/
 date: '2026-05-05'
-last_updated: '2026-05-05'
+last_updated: '2026-06-04'
 tags:
   - オープンソース
   - CLI
@@ -20,7 +20,7 @@ quick_summary:
   target_users:
     - 開発者
     - AIエージェント利用者
-  latest_highlight: v0.38.0リリース
+  latest_highlight: v0.42.1リリース
   update_frequency: 高
 evaluation:
   score: 85
@@ -191,7 +191,9 @@ relationships:
 
 ## **15. 直近半年のアップデート情報**
 
-* **2026-04-29**: v0.38.0 リリース (各種コマンドのパーサー改善など)
+* **2026-06-03**: v0.42.1 リリース (openclawプラグインでの危険なコマンド実行を回避するための修正など)
+* **2026-05-13**: v0.40.0 リリース (Android/Kotlin向けのGradleサポート追加、Hermes Agentサポートの追加など)
+* **2026-04-29**: v0.38.0 リリース (GitLab CLIサポート追加など)
 
 (出典: [リリースノート](https://github.com/rtk-ai/rtk/releases) )
 


### PR DESCRIPTION
- Updated `last_updated` date to 2026-06-04.
- Updated `latest_highlight` to v0.42.1 release.
- Added recent v0.42.1 and v0.40.0 release details to the 15th section in the markdown.

---
*PR created automatically by Jules for task [16332896202517012711](https://jules.google.com/task/16332896202517012711) started by @aegisfleet*