### PR TITLE
chore: Reorganize Categories according to task organizing instructions

### DIFF
--- a/_reports/copilotkit.md
+++ b/_reports/copilotkit.md
@@ -2,15 +2,15 @@
 title: CopilotKit 調査レポート
 tool_name: CopilotKit
 tool_reading: コパイロットキット
-category: AI開発者ツール
+category: AI開発ライブラリ
 developer: Tawkit, Inc.
 official_site: https://www.copilotkit.ai/
 date: '2026-06-06'
 last_updated: '2026-06-06'
 tags:
-  - React
+  - JavaScript
   - 生成AI
-  - UIフレームワーク
+  - 開発者ツール
   - エージェント
   - オープンソース
 description: ReactアプリにAIチャットや生成AIコンポーネントを簡単に組み込めるフルスタックエージェントSDK


### PR DESCRIPTION
Reorganize categories as part of the daily automated workflow based on task-organizing-category-tags.md. The single isolated category `AI開発者ツール` was integrated into `AI開発ライブラリ`. Splitting was skipped since no explicit criteria triggered a division. Other 1-2 elements were retained since they are well-defined.

---
*PR created automatically by Jules for task [54642504450022006](https://jules.google.com/task/54642504450022006) started by @aegisfleet*