### PR TITLE
Organize categories

### DIFF
--- a/_reports/apple-container.md
+++ b/_reports/apple-container.md
@@ -2,12 +2,13 @@
 title: Apple Container 調査レポート
 tool_name: Apple Container
 tool_reading: アップルコンテナ / コンテナ
-category: 開発者ツール
+category: 開発ユーティリティ
 developer: Apple
 official_site: https://github.com/apple/container
 date: '2026-06-14'
 last_updated: '2026-06-14'
 tags:
+  - 開発者ツール
   - コンテナ
   - 仮想化
   - macOS

--- a/_reports/parallels-desktop.md
+++ b/_reports/parallels-desktop.md
@@ -2,7 +2,7 @@
 title: Parallels Desktop for Mac 調査レポート
 tool_name: Parallels Desktop for Mac
 tool_reading: パラレルス デスクトップ フォー マック
-category: 仮想化・エミュレーター
+category: OS/プラットフォーム
 developer: Parallels International GmbH
 official_site: https://www.parallels.com/products/desktop/
 date: '2026-06-14'
@@ -41,10 +41,6 @@ evaluation:
   summary: Mac上でWindowsを実行するための最も完成されたソリューションであり、特にApple Silicon環境でのパフォーマンスと使い勝手に優れている
 links:
   documentation: https://kb.parallels.com/
-relationships:
-  related_tools:
-    - VMware Fusion
-    - UTM
 ---
 
 # **Parallels Desktop for Mac 調査レポート**

--- a/_reports/webcam-vtuber.md
+++ b/_reports/webcam-vtuber.md
@@ -2,7 +2,7 @@
 title: Webcam VTuber 調査レポート
 tool_name: Webcam VTuber
 tool_reading: ウェブカムブイチューバー
-category: VTuber配信ツール
+category: 動画/メディア
 developer: 株式会社ユーザーローカル
 official_site: https://vtuber.userlocal.jp/
 date: '2026-06-13'


### PR DESCRIPTION
This pull request organizes categories based on the `task-organizing-category-tags.md` instructions.

- Checked the `_data/categories.yml` files and existing `_reports/*.md`.
- Consolidated the 3 small categories (1-2 uses):
    - `開発者ツール` -> `開発ユーティリティ`
    - `仮想化・エミュレーター` -> `OS/プラットフォーム`
    - `VTuber配信ツール` -> `動画/メディア`
- Kept the 10+ item categories as is (as no clear splits were found or needed).
- Added `開発者ツール` tag to `apple-container.md` to keep context.
- Removed invalid relationships `VMware Fusion` and `UTM` from `parallels-desktop.md` since they don't have existing reports.
- Confirmed that everything passes tests with `pnpm lint:yaml`, `pnpm check-links`, and script tests for `relationships`.

---
*PR created automatically by Jules for task [2522013139957750785](https://jules.google.com/task/2522013139957750785) started by @aegisfleet*