### PR TITLE
Add Dependency-Check report

### DIFF
--- a/_reports/dependabot.md
+++ b/_reports/dependabot.md
@@ -51,6 +51,7 @@ relationships:
     - CodeRabbit
     - SonarQube
     - Renovate
+    - Dependency-Check
 ---
 
 # **Dependabot 調査レポート**

--- a/_reports/dependency-check.md
+++ b/_reports/dependency-check.md
@@ -1,0 +1,226 @@
+---
+title: Dependency-Check 調査レポート
+tool_name: Dependency-Check
+tool_reading: ディペンデンシーチェック
+category: セキュリティ
+developer: OWASP
+official_site: https://owasp.org/www-project-dependency-check/
+date: '2026-06-22'
+last_updated: '2026-06-22'
+tags:
+  - セキュリティ
+  - オープンソース
+  - 脆弱性診断
+  - CI/CD
+  - DevSecOps
+description: プロジェクトの依存関係に潜む既知の脆弱性を検出し、安全な開発を支援するオープンソースのSCAツール。
+quick_summary:
+  has_free_plan: true
+  is_oss: true
+  starting_price: 無料
+  target_users:
+    - 開発者
+    - セキュリティエンジニア
+  latest_highlight: バージョン12.2.x系がリリースされ、各種パッケージ管理ツール向けの対応を強化
+  update_frequency: 高
+evaluation:
+  score: 80
+  base_score: 70
+  plus_points:
+    - point: 5
+      reason: オープンソースであり、CI/CD環境に容易に組み込める
+    - point: 5
+      reason: 様々な言語やパッケージマネージャの依存関係を幅広くスキャン可能
+    - point: 3
+      reason: OWASPのフラッグシッププロジェクトとしての高い信頼性
+  minus_points:
+    - point: -3
+      reason: NVDデータのダウンロードに時間がかかる場合がある
+  summary: オープンソースで手軽に導入できるSCAツールだが、NVDの初回同期に時間がかかる点に注意が必要。
+links:
+  github: https://github.com/dependency-check/DependencyCheck
+  deepwiki: https://deepwiki.com/dependency-check/DependencyCheck
+  documentation: https://dependency-check.github.io/DependencyCheck/
+relationships:
+  related_tools:
+    - Dependabot
+    - Trivy
+---
+
+# **Dependency-Check 調査レポート**
+
+## **1. 基本情報**
+
+* **ツール名**: OWASP Dependency-Check
+* **ツールの読み方**: ディペンデンシーチェック
+* **開発元**: OWASP Foundation
+* **公式サイト**: [https://owasp.org/www-project-dependency-check/](https://owasp.org/www-project-dependency-check/)
+* **関連リンク**:
+  * GitHub: [https://github.com/dependency-check/DependencyCheck](https://github.com/dependency-check/DependencyCheck)
+  * DeepWiki: [https://deepwiki.com/dependency-check/DependencyCheck](https://deepwiki.com/dependency-check/DependencyCheck)
+  * ドキュメント: [https://dependency-check.github.io/DependencyCheck/](https://dependency-check.github.io/DependencyCheck/)
+* **カテゴリ**: セキュリティ
+* **概要**: OWASP Dependency-Checkは、アプリケーションの依存ライブラリに既知の脆弱性が含まれていないかを検出するオープンソースのソフトウェアコンポジション解析（SCA）ツールである。NVD（National Vulnerability Database）などから情報を取得し、対象の依存関係に関連するCVEをレポートする。
+
+## **2. 目的と主な利用シーン**
+
+* **解決する課題**: サードパーティ製のオープンソースコンポーネントを使用する際に生じる、既知の脆弱性を利用された攻撃リスクの低減。
+* **想定利用者**: ソフトウェア開発者、セキュリティエンジニア、DevSecOps担当者。
+* **利用シーン**:
+  * CI/CDパイプラインに組み込み、ビルドごとに自動で脆弱性をスキャンする。
+  * ローカル環境でコードの依存関係をスキャンし、開発の初期段階で問題を検出する。
+  * プロジェクトの監査時に、レポートを生成してセキュリティ状況を可視化する。
+
+## **3. 主要機能**
+
+* **広範な依存関係スキャン**: Java、.NET、JavaScript、Ruby、Pythonなど、多様な言語やパッケージマネージャの依存関係をスキャン可能。
+* **CVEマッピング**: 検出されたコンポーネントをNVDデータのCPE（Common Platform Enumeration）と照合し、関連するCVEエントリーを特定する。
+* **多様な連携形式**: コマンドライン（CLI）ツールとしての利用のほか、Maven、Gradle、Antなどのビルドツール用プラグインが提供されている。
+* **CI/CDインテグレーション**: Jenkins、SonarQube、GitHub Actions、Azure DevOpsなどへの統合ツールがコミュニティベースで提供されている。
+* **レポート生成**: HTML、XML、JSON、CSVなど、様々な形式で詳細な脆弱性レポートを出力できる。
+
+## **4. 開始手順・セットアップ**
+
+* **前提条件**:
+  * Java Runtime Environment（JRE）のインストール（動作にJavaが必要）。
+  * インターネット接続（NVDデータのダウンロードに使用）。
+* **インストール/導入**:
+
+  ```bash
+  # Mac (Homebrewの場合)
+  brew install dependency-check
+
+  # Dockerの場合
+  docker pull owasp/dependency-check
+  ```
+
+* **初期設定**:
+  * 特別なアカウント登録やAPIキーの設定は不要。CLIやプラグインをダウンロードするだけで利用開始できる。
+  * ※ NVD APIの利用制限を回避するために、NVD API Keyを取得して設定することが推奨されている。
+* **クイックスタート**:
+  * プロジェクトのルートディレクトリで以下のコマンドを実行する（CLIの場合）。
+
+  ```bash
+  dependency-check --project "My Project" --scan .
+  ```
+  * 初回実行時はNVDデータのダウンロードに10分以上の時間がかかる場合がある。
+
+## **5. 特徴・強み (Pros)**
+
+* **オープンソースで無料**: エンタープライズ向けのSCAツールが高価な中、完全無料で利用できる点は非常に強力。
+* **プラットフォームの柔軟性**: CLI、Maven、Gradleなど導入手段が豊富で、既存のビルドプロセスへ容易に統合できる。
+* **OWASPの公式プロジェクト**: 信頼性の高いOWASP（Open Worldwide Application Security Project）のフラッグシッププロジェクトとして開発・保守されている。
+
+## **6. 弱み・注意点 (Cons)**
+
+* **初回スキャンの遅延**: NVDデータセットの初回ダウンロードに時間がかかる。キャッシュ戦略やローカルミラーの設定を行わないと、CI/CD環境での実行にボトルネックが生じやすい。
+* **誤検知（False Positives）**: ハッシュベースではなくメタデータやファイル名からのヒューリスティックな照合を行うため、誤検知や検知漏れが発生する可能性がある。手動でのサプレッション（Suppression）設定によるチューニングが必要になることがある。
+* **日本語対応**: UIや生成されるレポートは基本的に英語であり、日本語へのローカライズは不十分。
+
+## **7. 料金プラン**
+
+| プラン名 | 料金 | 主な特徴 |
+|---------|------|---------|
+| **オープンソース版** | 無料 | すべての機能が無料で利用可能。コミュニティベースのサポート。 |
+
+* **課金体系**: 完全無料（Apache 2.0 License）。
+* **無料トライアル**: なし（常に無料）。
+
+## **8. 導入実績・事例**
+
+* **導入企業**: 世界中の多数の企業、オープンソースプロジェクト、政府機関などで採用されている。
+* **導入事例**: DevSecOpsの推進において、CI/CDパイプラインの脆弱性スキャンの第一歩として導入されるケースが多い。
+* **対象業界**: ソフトウェア開発を行うあらゆる業界。
+
+## **9. サポート体制**
+
+* **ドキュメント**: 公式サイト（GitHub Pages）に、アーキテクチャから各プラグインの設定方法まで網羅したドキュメントが存在する。
+* **コミュニティ**: GitHub IssuesやOWASPのSlackチャンネルで活発な議論やサポートが行われている。
+* **公式サポート**: オープンソースであるため、企業向けの有償公式サポートは提供されていない（コミュニティサポートのみ）。
+
+## **10. エコシステムと連携**
+
+### **10.1 API・外部サービス連携**
+
+* **API**: サードパーティサービス（NPM Audit、OSS Index、RetireJSなど）のAPIを呼び出して脆弱性情報を補完する機能がある。
+* **外部サービス連携**: Jenkins、SonarQube、GitHub Actionsなど、様々なCI/CDツールとの連携用プラグインが存在する。
+
+### **10.2 技術スタックとの相性**
+
+| 技術スタック | 相性 | メリット・推奨理由 | 懸念点・注意点 |
+|:---|:---:|:---|:---|
+| **Java (Maven/Gradle)** | ◎ | 公式プラグインが提供されており、pom.xmlやbuild.gradleから直接スキャンが可能。 | 特になし。 |
+| **Node.js (npm/yarn)** | ◯ | `package.json`やロックファイルを解析可能。NPM Auditなどと連携して検知精度を高めている。 | 大量の依存関係がある場合、スキャンに時間がかかることがある。 |
+| **Python** | ◯ | `requirements.txt`や`Pipfile`の解析（Experimentalアナライザー）に対応。 | 一部の機能はExperimental扱いであり、検知精度にばらつきが生じる可能性がある。 |
+| **.NET** | ◯ | AssemblyやNugetパッケージの解析に対応。 | 実行環境としてdotnet coreランタイムが必要になる場合がある。 |
+
+## **11. セキュリティとコンプライアンス**
+
+* **認証**: ツール自体の利用にアカウント認証は不要。NVD APIなどを利用する場合はAPIキーを設定できる。
+* **データ管理**: スキャン対象のコードやバイナリはローカル（実行環境）で処理され、SaaSへアップロードされることはないため、ソースコード流出のリスクは極めて低い。
+* **準拠規格**: OWASP Top 10（特にA06:2021 – Vulnerable and Outdated Components）への対応を支援する目的で作られている。
+
+## **12. 操作性 (UI/UX) と学習コスト**
+
+* **UI/UX**: コマンドラインツールおよびHTMLレポートのUIはシンプルで実用的。
+* **学習コスト**: 基本的なコマンドやプラグインの実行方法は簡単だが、誤検知を抑制するためのサプレッションファイル（XML）の記述などには一定の学習が必要。
+
+## **13. ベストプラクティス**
+
+* **効果的な活用法 (Modern Practices)**:
+  * **NVDデータのキャッシュ・ミラーリング**: CI/CD環境で毎回NVDデータをダウンロードするのを防ぐため、ローカルミラーやキャッシュDBを構築し、スキャン時間を短縮する。
+  * **CI/CDパイプラインでの自動実行**: JenkinsやGitHub ActionsでビルドステップにDependency-Checkを組み込み、一定のCVSSスコア以上の脆弱性が検知された場合にビルドを失敗させる（Fail the build）運用にする。
+* **陥りやすい罠 (Antipatterns)**:
+  * **誤検知の放置**: 誤検知（False Positives）による大量のアラートを放置すると、開発者がレポートを見なくなり形骸化する。必ずサプレッションファイルを利用して誤検知を除外する運用をセットにする。
+  * **NVD初回ダウンロードのタイムアウト**: CI環境で初回同期時にタイムアウトエラーになることが多いため、定期的なキャッシュ更新ジョブを別途設けるのが望ましい。
+
+## **14. ユーザーの声（レビュー分析）**
+
+* **調査対象**: G2、Capterra、GitHub Issues、Tech Blog
+* **総合評価**: 無料のSCAツールとしてはデファクトスタンダードであり、高い評価を得ている。
+* **ポジティブな評価**:
+  * 「無料でここまでの精度とカバレッジを提供してくれるツールは他にない。」
+  * 「JenkinsなどのCIに簡単に組み込めて、ビルドをブロックできるのが便利。」
+* **ネガティブな評価 / 改善要望**:
+  * 「NVDのダウンロードがとにかく遅い。APIの制限に引っかかることが多い。」
+  * 「Java以外の言語（特にC/C++など）での誤検知が多く、サプレッションの管理が大変。」
+* **特徴的なユースケース**:
+  * 商用のSCAツール（Snykなど）を全社導入する前のPoCや、予算が限られているオープンソースプロジェクトでのセキュリティチェックとしての利用。
+
+## **15. 直近半年のアップデート情報**
+
+* **2026-05-03**: バージョン 12.2.2 リリース（不具合の修正とパフォーマンス改善）
+* **2026-04-11**: バージョン 12.2.1 リリース
+* **2026-01-09**: バージョン 12.2.0 リリース
+* **2025-11-11**: バージョン 12.1.9 リリース
+
+(出典: [GitHub Releases](https://github.com/dependency-check/DependencyCheck/releases))
+
+## **16. 類似ツールとの比較**
+
+### **16.1 機能比較表 (星取表)**
+
+| 機能カテゴリ | 機能項目 | 本ツール | Dependabot | Trivy | Snyk |
+|:---:|:---|:---:|:---:|:---:|:---:|
+| **基本機能** | 脆弱性スキャン | ◎<br><small>ローカルで完結</small> | ◯<br><small>GitHub上で完結</small> | ◎<br><small>高速・多機能</small> | ◎<br><small>商用DBで高精度</small> |
+| **自動化** | 自動修正PR作成 | ×<br><small>機能なし</small> | ◎<br><small>標準機能</small> | ×<br><small>機能なし</small> | ◎<br><small>標準機能</small> |
+| **対象** | コンテナ対応 | ×<br><small>対応なし</small> | ×<br><small>一部のみ</small> | ◎<br><small>コンテナ特化</small> | ◎<br><small>対応</small> |
+| **コスト** | 無料利用 | ◎<br><small>完全無料</small> | ◎<br><small>無料利用可</small> | ◎<br><small>OSS版あり</small> | △<br><small>無料枠あり/基本有料</small> |
+
+### **16.2 詳細比較**
+
+| ツール名 | 特徴 | 強み | 弱み | 選択肢となるケース |
+|---------|------|------|------|------------------|
+| **Dependency-Check** | OWASPのOSS SCAツール | 無料、ローカル実行可能、Java環境に強い | 誤検知が多い、NVDの同期が重い、自動修復機能がない | 予算をかけずにCI/CDで脆弱性スキャンを行いたい場合、SaaSにコードをアップロードしたくない場合。 |
+| **Dependabot** | GitHub組み込みの更新ツール | 導入の手間がゼロ、自動で修正PRを作成 | 細かい設定が難しい、GitHubに依存する | GitHubを利用しており、依存関係のバージョンアップと脆弱性対策を手間なく行いたい場合。 |
+| **Trivy** | Aqua Securityが提供するスキャナ | 超高速、コンテナイメージやIaCもスキャン可能 | SBOM生成等はできるが、自動PR作成機能はない | コンテナを利用しており、インフラからアプリの依存関係まで統合して高速にスキャンしたい場合。 |
+| **Snyk** | セキュリティ特化のSaaS | 独自の脆弱性DBを持ち高精度、IDE連携や自動修復が強力 | フル機能の利用には有償プランが必要 | セキュリティを最重要視し、開発者の生産性を落とさずにエンタープライズレベルの対策を行いたい場合。 |
+
+## **17. 総評**
+
+* **総合的な評価**:
+  OWASP Dependency-Checkは、ソフトウェア構成分析（SCA）を無料で始めるための非常に優れたツールである。NVDデータのダウンロード時間の長さや、ヒューリスティックな検知による誤検知の多さなど、運用面での工夫（キャッシュ、サプレッション設定）は必要になるものの、多様な言語に対応しCI/CDへ簡単に組み込める点は高く評価できる。
+* **推奨されるチームやプロジェクト**:
+  SaaS型セキュリティツールの導入が難しいオンプレミス環境のプロジェクトや、予算が限られているチーム、Javaをメインに使用しているプロジェクトに特に推奨される。
+* **選択時のポイント**:
+  自動でアップデートPRを作成してほしい場合はDependabot、コンテナを中心にスキャンしたい場合はTrivy、高精度で開発者体験を重視する場合はSnykなど、プロジェクトの要件や環境に応じて使い分ける、または組み合わせるのが望ましい。

--- a/_reports/trivy.md
+++ b/_reports/trivy.md
@@ -45,6 +45,7 @@ relationships:
     - GitHub Actions
     - Jenkins
     - GitLab CI/CD
+    - Dependency-Check
 ---
 
 # **Trivy 調査レポート**


### PR DESCRIPTION
Added a comprehensive analysis report for OWASP Dependency-Check tool based on the standard `template.md`. Updated related tools (`Dependabot`, `Trivy`) to reference the newly added report. Verified links and formatted frontmatter.

---
*PR created automatically by Jules for task [5827849341400188236](https://jules.google.com/task/5827849341400188236) started by @aegisfleet*