### PR TITLE
refactor(categories): split ビジネス/業務ツール and skip others

### DIFF
--- a/_reports/copilot-cowork.md
+++ b/_reports/copilot-cowork.md
@@ -2,7 +2,7 @@
 title: Copilot Cowork 調査レポート
 tool_name: Copilot Cowork
 tool_reading: コパイロット コワーク
-category: ビジネス/業務ツール
+category: 汎用AIエージェント
 developer: Microsoft
 official_site: https://adoption.microsoft.com/en-us/copilot/frontier-program/
 date: '2026-03-16'

--- a/_reports/dexter.md
+++ b/_reports/dexter.md
@@ -2,7 +2,7 @@
 title: Dexter 調査レポート
 tool_name: Dexter
 tool_reading: デクスター
-category: ビジネス/業務ツール
+category: 汎用AIエージェント
 developer: virattt
 official_site: https://github.com/virattt/dexter
 date: '2026-03-27'

--- a/_reports/litron-core.md
+++ b/_reports/litron-core.md
@@ -2,7 +2,7 @@
 title: LITRON CORE 調査レポート
 tool_name: LITRON CORE
 tool_reading: リトロン コア
-category: ビジネス/業務ツール
+category: 汎用AIエージェント
 developer: NTTデータ (NTT DATA)
 official_site: https://www.nttdata.com/jp/ja/lineup/litron-core/
 date: '2026-01-28'


### PR DESCRIPTION
Split "ビジネス/業務ツール" by reclassifying "Dexter", "LITRON CORE", and "Copilot Cowork" to "汎用AIエージェント" based on their AI agent capabilities. 
The remaining 10+ count categories were skipped as "同一カテゴリが適切で分割軸が見当たらない" (they are appropriate as-is and lack a clear splitting axis) or "分割後の各カテゴリが2件以下になる場合" (the resulting split categories would be 2 or fewer).
Verified that changes were minimal and relationship links were preserved.

---
*PR created automatically by Jules for task [11517238604515548136](https://jules.google.com/task/11517238604515548136) started by @aegisfleet*