### PR TITLE
Update Windsurf report and reflect rename to Devin Desktop

### DIFF
--- a/_reports/aquavoice.md
+++ b/_reports/aquavoice.md
@@ -8,41 +8,41 @@ official_site: https://aquavoice.com/
 date: '2026-03-01'
 last_updated: '2026-06-10'
 tags:
-  - エージェント
-  - コーディング支援
-  - 生産性向上
-  - 音声入力
+- エージェント
+- コーディング支援
+- 生産性向上
+- 音声入力
 description: 開発者やAIツールに特化し、画面のコンテキストを理解して高精度なテキスト変換を行う音声入力ツール
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: $8/月
   target_users:
-    - 開発者
-    - プロダクトマネージャー
+  - 開発者
+  - プロダクトマネージャー
   latest_highlight: 2026年6月にエンタープライズプランを追加し、iOSアプリもリリース
   update_frequency: 高
 evaluation:
   score: 79
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 開発用語やAI関連用語の認識精度が非常に高い（独自モデルAvalon）
-    - point: 3
-      reason: 画面上のコンテキスト（コードなど）を読み取り、出力内容を最適化可能
-    - point: 3
-      reason: あらゆるテキストボックスで直接利用できる汎用性の高さ
+  - point: 5
+    reason: 開発用語やAI関連用語の認識精度が非常に高い（独自モデルAvalon）
+  - point: 3
+    reason: 画面上のコンテキスト（コードなど）を読み取り、出力内容を最適化可能
+  - point: 3
+    reason: あらゆるテキストボックスで直接利用できる汎用性の高さ
   minus_points:
-    - point: -2
-      reason: 独自の高性能モデルAvalonの利用には有料プラン（Pro）が必要
+  - point: -2
+    reason: 独自の高性能モデルAvalonの利用には有料プラン（Pro）が必要
   summary: AIコーディング支援ツール（Cursor, Claude Codeなど）でのプロンプト入力や、日常の開発コミュニケーションにおいて圧倒的な生産性向上をもたらす音声入力ツール
 relationships:
   related_tools:
-    - Cursor
-    - Claude Code
-    - Windsurf
-    - VibeVoice
-    - Notely Voice
+  - Cursor
+  - Claude Code
+  - Devin Desktop
+  - VibeVoice
+  - Notely Voice
 ---
 
 # **Aqua Voice 調査レポート**

--- a/_reports/aquavoice.md
+++ b/_reports/aquavoice.md
@@ -8,41 +8,41 @@ official_site: https://aquavoice.com/
 date: '2026-03-01'
 last_updated: '2026-06-10'
 tags:
-- エージェント
-- コーディング支援
-- 生産性向上
-- 音声入力
+  - エージェント
+  - コーディング支援
+  - 生産性向上
+  - 音声入力
 description: 開発者やAIツールに特化し、画面のコンテキストを理解して高精度なテキスト変換を行う音声入力ツール
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: $8/月
   target_users:
-  - 開発者
-  - プロダクトマネージャー
+    - 開発者
+    - プロダクトマネージャー
   latest_highlight: 2026年6月にエンタープライズプランを追加し、iOSアプリもリリース
   update_frequency: 高
 evaluation:
   score: 79
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 開発用語やAI関連用語の認識精度が非常に高い（独自モデルAvalon）
-  - point: 3
-    reason: 画面上のコンテキスト（コードなど）を読み取り、出力内容を最適化可能
-  - point: 3
-    reason: あらゆるテキストボックスで直接利用できる汎用性の高さ
+    - point: 5
+      reason: 開発用語やAI関連用語の認識精度が非常に高い（独自モデルAvalon）
+    - point: 3
+      reason: 画面上のコンテキスト（コードなど）を読み取り、出力内容を最適化可能
+    - point: 3
+      reason: あらゆるテキストボックスで直接利用できる汎用性の高さ
   minus_points:
-  - point: -2
-    reason: 独自の高性能モデルAvalonの利用には有料プラン（Pro）が必要
+    - point: -2
+      reason: 独自の高性能モデルAvalonの利用には有料プラン（Pro）が必要
   summary: AIコーディング支援ツール（Cursor, Claude Codeなど）でのプロンプト入力や、日常の開発コミュニケーションにおいて圧倒的な生産性向上をもたらす音声入力ツール
 relationships:
   related_tools:
-  - Cursor
-  - Claude Code
-  - Devin Desktop
-  - VibeVoice
-  - Notely Voice
+    - Cursor
+    - Claude Code
+    - Devin Desktop
+    - VibeVoice
+    - Notely Voice
 ---
 
 # **Aqua Voice 調査レポート**

--- a/_reports/cc-sdd.md
+++ b/_reports/cc-sdd.md
@@ -8,34 +8,34 @@ official_site: https://github.com/gotalab/cc-sdd
 date: '2026-03-09'
 last_updated: '2026-06-23'
 tags:
-- AI
-- CLI
-- エージェント
-- オープンソース
-- 自動化
+  - AI
+  - CLI
+  - エージェント
+  - オープンソース
+  - 自動化
 description: AIコーディングエージェントに仕様書駆動開発（SDD）のワークフローを導入するCLIツール。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-  - 開発者
-  - 開発チーム
+    - 開発者
+    - 開発チーム
   latest_highlight: 2026年4月にAgent Skillsモードの追加と自律的実装（/kiro-impl）をサポートするv3.0.0をリリース
   update_frequency: 中
 evaluation:
   score: 83
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 複数の主要なAIエディタ/CLI（Claude Code, Cursorなど計8種）をサポートしている
-  - point: 5
-    reason: 要件定義から実装タスクまでを構造化し、AIによる手戻りを防ぐ独自のアプローチ
-  - point: 3
-    reason: オープンソースであり無料で利用可能、導入も容易
+    - point: 5
+      reason: 複数の主要なAIエディタ/CLI（Claude Code, Cursorなど計8種）をサポートしている
+    - point: 5
+      reason: 要件定義から実装タスクまでを構造化し、AIによる手戻りを防ぐ独自のアプローチ
+    - point: 3
+      reason: オープンソースであり無料で利用可能、導入も容易
   minus_points:
-  - point: 0
-    reason: 特になし
+    - point: 0
+      reason: 特になし
   summary: 既存のAIコーディングツールに仕様書駆動プロセスを後付けできる、非常に実用的かつ画期的なオープンソースツール。
 links:
   github: https://github.com/gotalab/cc-sdd
@@ -43,11 +43,11 @@ links:
   deepwiki: https://deepwiki.com/gotalab/cc-sdd
 relationships:
   related_tools:
-  - Kiro
-  - Claude Code
-  - Cursor
-  - Devin Desktop
-  - GitHub Copilot
+    - Kiro
+    - Claude Code
+    - Cursor
+    - Devin Desktop
+    - GitHub Copilot
 ---
 
 # **cc-sdd 調査レポート**

--- a/_reports/cc-sdd.md
+++ b/_reports/cc-sdd.md
@@ -8,34 +8,34 @@ official_site: https://github.com/gotalab/cc-sdd
 date: '2026-03-09'
 last_updated: '2026-06-23'
 tags:
-  - AI
-  - CLI
-  - エージェント
-  - オープンソース
-  - 自動化
+- AI
+- CLI
+- エージェント
+- オープンソース
+- 自動化
 description: AIコーディングエージェントに仕様書駆動開発（SDD）のワークフローを導入するCLIツール。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-    - 開発者
-    - 開発チーム
+  - 開発者
+  - 開発チーム
   latest_highlight: 2026年4月にAgent Skillsモードの追加と自律的実装（/kiro-impl）をサポートするv3.0.0をリリース
   update_frequency: 中
 evaluation:
   score: 83
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 複数の主要なAIエディタ/CLI（Claude Code, Cursorなど計8種）をサポートしている
-    - point: 5
-      reason: 要件定義から実装タスクまでを構造化し、AIによる手戻りを防ぐ独自のアプローチ
-    - point: 3
-      reason: オープンソースであり無料で利用可能、導入も容易
+  - point: 5
+    reason: 複数の主要なAIエディタ/CLI（Claude Code, Cursorなど計8種）をサポートしている
+  - point: 5
+    reason: 要件定義から実装タスクまでを構造化し、AIによる手戻りを防ぐ独自のアプローチ
+  - point: 3
+    reason: オープンソースであり無料で利用可能、導入も容易
   minus_points:
-    - point: 0
-      reason: 特になし
+  - point: 0
+    reason: 特になし
   summary: 既存のAIコーディングツールに仕様書駆動プロセスを後付けできる、非常に実用的かつ画期的なオープンソースツール。
 links:
   github: https://github.com/gotalab/cc-sdd
@@ -43,11 +43,11 @@ links:
   deepwiki: https://deepwiki.com/gotalab/cc-sdd
 relationships:
   related_tools:
-    - Kiro
-    - Claude Code
-    - Cursor
-    - Windsurf
-    - GitHub Copilot
+  - Kiro
+  - Claude Code
+  - Cursor
+  - Devin Desktop
+  - GitHub Copilot
 ---
 
 # **cc-sdd 調査レポート**

--- a/_reports/claude-code.md
+++ b/_reports/claude-code.md
@@ -8,33 +8,33 @@ official_site: https://claude.ai/code
 date: '2026-01-24'
 last_updated: '2026-04-01'
 tags:
-  - AI
-  - エージェント
-  - コーディング支援
-  - 自律型
-  - 開発者ツール
+- AI
+- エージェント
+- コーディング支援
+- 自律型
+- 開発者ツール
 description: Anthropicが提供する、ターミナルやIDEで動作する自律型コーディングエージェント。最新のClaude 4.5モデルを使用。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: プランに含む
   target_users:
-    - 開発者
-    - DevOpsエンジニア
+  - 開発者
+  - DevOpsエンジニア
   latest_highlight: 2026年4月に各種不具合修正やheadless session向けのフック強化を含むv2.1.89をリリース
   update_frequency: 高
 evaluation:
   score: 88
   base_score: 70
   plus_points:
-    - point: 5
-      reason: Claude 4.5 Opus/Sonnetの強力な推論能力を活用
-    - point: 5
-      reason: Agentic searchによる深いコードベース理解
-    - point: 5
-      reason: ターミナル、IDE、Slack、Webと柔軟な環境対応
-    - point: 3
-      reason: MCPによる高い拡張性
+  - point: 5
+    reason: Claude 4.5 Opus/Sonnetの強力な推論能力を活用
+  - point: 5
+    reason: Agentic searchによる深いコードベース理解
+  - point: 5
+    reason: ターミナル、IDE、Slack、Webと柔軟な環境対応
+  - point: 3
+    reason: MCPによる高い拡張性
   minus_points: []
   summary: ターミナルやIDEで自律的にタスクをこなす強力なエージェント。Claude 4.5の搭載により信頼性と解決力がさらに向上した。
 links:
@@ -44,20 +44,20 @@ links:
 relationships:
   parent: Claude
   children:
-    - Opcode
+  - Opcode
   related_tools:
-    - Spec Kit
-    - GitHub Copilot
-    - Cursor
-    - Windsurf
-    - Cline
-    - Devin
-    - Grok CLI
-    - Roola
-    - Agent Governance Toolkit
-    - Headroom
-    - Aqua Voice
-    - Agentic Workflows
+  - Spec Kit
+  - GitHub Copilot
+  - Cursor
+  - Devin Desktop
+  - Cline
+  - Devin
+  - Grok CLI
+  - Roola
+  - Agent Governance Toolkit
+  - Headroom
+  - Aqua Voice
+  - Agentic Workflows
 ---
 # **Claude Code 調査レポート**
 

--- a/_reports/claude-code.md
+++ b/_reports/claude-code.md
@@ -8,33 +8,33 @@ official_site: https://claude.ai/code
 date: '2026-01-24'
 last_updated: '2026-04-01'
 tags:
-- AI
-- エージェント
-- コーディング支援
-- 自律型
-- 開発者ツール
+  - AI
+  - エージェント
+  - コーディング支援
+  - 自律型
+  - 開発者ツール
 description: Anthropicが提供する、ターミナルやIDEで動作する自律型コーディングエージェント。最新のClaude 4.5モデルを使用。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: プランに含む
   target_users:
-  - 開発者
-  - DevOpsエンジニア
+    - 開発者
+    - DevOpsエンジニア
   latest_highlight: 2026年4月に各種不具合修正やheadless session向けのフック強化を含むv2.1.89をリリース
   update_frequency: 高
 evaluation:
   score: 88
   base_score: 70
   plus_points:
-  - point: 5
-    reason: Claude 4.5 Opus/Sonnetの強力な推論能力を活用
-  - point: 5
-    reason: Agentic searchによる深いコードベース理解
-  - point: 5
-    reason: ターミナル、IDE、Slack、Webと柔軟な環境対応
-  - point: 3
-    reason: MCPによる高い拡張性
+    - point: 5
+      reason: Claude 4.5 Opus/Sonnetの強力な推論能力を活用
+    - point: 5
+      reason: Agentic searchによる深いコードベース理解
+    - point: 5
+      reason: ターミナル、IDE、Slack、Webと柔軟な環境対応
+    - point: 3
+      reason: MCPによる高い拡張性
   minus_points: []
   summary: ターミナルやIDEで自律的にタスクをこなす強力なエージェント。Claude 4.5の搭載により信頼性と解決力がさらに向上した。
 links:
@@ -44,20 +44,20 @@ links:
 relationships:
   parent: Claude
   children:
-  - Opcode
+    - Opcode
   related_tools:
-  - Spec Kit
-  - GitHub Copilot
-  - Cursor
-  - Devin Desktop
-  - Cline
-  - Devin
-  - Grok CLI
-  - Roola
-  - Agent Governance Toolkit
-  - Headroom
-  - Aqua Voice
-  - Agentic Workflows
+    - Spec Kit
+    - GitHub Copilot
+    - Cursor
+    - Devin Desktop
+    - Cline
+    - Devin
+    - Grok CLI
+    - Roola
+    - Agent Governance Toolkit
+    - Headroom
+    - Aqua Voice
+    - Agentic Workflows
 ---
 # **Claude Code 調査レポート**
 

--- a/_reports/cline.md
+++ b/_reports/cline.md
@@ -8,41 +8,41 @@ official_site: https://cline.bot/
 date: '2025-10-23'
 last_updated: '2026-06-18'
 tags:
-- AI
-- エージェント
-- オープンソース
-- コーディング支援
-- 開発者ツール
+  - AI
+  - エージェント
+  - オープンソース
+  - コーディング支援
+  - 開発者ツール
 description: VS CodeなどのIDE内で動作する協調型AIコーディングエージェント。ローカルのコードベース全体を直接理解し、人間と協力して計画を立て、変更を実行する。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-  - 開発者
-  - シニアエンジニア
-  - セキュリティ意識の高い企業
+    - 開発者
+    - シニアエンジニア
+    - セキュリティ意識の高い企業
   latest_highlight: 2026年6月にClaude Fable 5やGPT-5.5等の最新モデルに対応し、CLIのskillコマンドを追加
   update_frequency: 高
 evaluation:
   score: 81
   base_score: 70
   plus_points:
-  - point: 8
-    reason: コードベース全体を理解する高いコンテキスト能力と、最新LLMへの迅速な対応
-  - point: 5
-    reason: コードがローカル環境で完結する高いセキュリティ
-  - point: 5
-    reason: オープンソースによる透明性とカスタマイズ性
-  - point: 3
-    reason: Hooks機能による高い拡張性
+    - point: 8
+      reason: コードベース全体を理解する高いコンテキスト能力と、最新LLMへの迅速な対応
+    - point: 5
+      reason: コードがローカル環境で完結する高いセキュリティ
+    - point: 5
+      reason: オープンソースによる透明性とカスタマイズ性
+    - point: 3
+      reason: Hooks機能による高い拡張性
   minus_points:
-  - point: -5
-    reason: BYOKモデルのため、タスクによってはAPI料金が高額になる可能性がある
-  - point: -3
-    reason: エージェントの能力を最大限に引き出すには習熟が必要で、学習コストが高い
-  - point: -2
-    reason: 公式ドキュメントやコミュニティが英語中心で、日本語の情報が少ない
+    - point: -5
+      reason: BYOKモデルのため、タスクによってはAPI料金が高額になる可能性がある
+    - point: -3
+      reason: エージェントの能力を最大限に引き出すには習熟が必要で、学習コストが高い
+    - point: -2
+      reason: 公式ドキュメントやコミュニティが英語中心で、日本語の情報が少ない
   summary: 高いカスタマイズ性とセキュリティを誇るが、コスト管理と学習曲線が課題となる上級者向けAIエージェント。
 links:
   github: https://github.com/cline/cline
@@ -51,14 +51,14 @@ links:
   documentation: https://docs.cline.bot/
 relationships:
   related_tools:
-  - Devin
-  - Cursor
-  - GitHub Copilot
-  - Devin Desktop
-  - Roo Code
-  - Visual Studio Code
-  - Model Context Protocol
-  - Agent Trace
+    - Devin
+    - Cursor
+    - GitHub Copilot
+    - Devin Desktop
+    - Roo Code
+    - Visual Studio Code
+    - Model Context Protocol
+    - Agent Trace
 ---
 
 # **Cline 調査レポート**

--- a/_reports/cline.md
+++ b/_reports/cline.md
@@ -8,41 +8,41 @@ official_site: https://cline.bot/
 date: '2025-10-23'
 last_updated: '2026-06-18'
 tags:
-  - AI
-  - エージェント
-  - オープンソース
-  - コーディング支援
-  - 開発者ツール
+- AI
+- エージェント
+- オープンソース
+- コーディング支援
+- 開発者ツール
 description: VS CodeなどのIDE内で動作する協調型AIコーディングエージェント。ローカルのコードベース全体を直接理解し、人間と協力して計画を立て、変更を実行する。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-    - 開発者
-    - シニアエンジニア
-    - セキュリティ意識の高い企業
+  - 開発者
+  - シニアエンジニア
+  - セキュリティ意識の高い企業
   latest_highlight: 2026年6月にClaude Fable 5やGPT-5.5等の最新モデルに対応し、CLIのskillコマンドを追加
   update_frequency: 高
 evaluation:
   score: 81
   base_score: 70
   plus_points:
-    - point: 8
-      reason: コードベース全体を理解する高いコンテキスト能力と、最新LLMへの迅速な対応
-    - point: 5
-      reason: コードがローカル環境で完結する高いセキュリティ
-    - point: 5
-      reason: オープンソースによる透明性とカスタマイズ性
-    - point: 3
-      reason: Hooks機能による高い拡張性
+  - point: 8
+    reason: コードベース全体を理解する高いコンテキスト能力と、最新LLMへの迅速な対応
+  - point: 5
+    reason: コードがローカル環境で完結する高いセキュリティ
+  - point: 5
+    reason: オープンソースによる透明性とカスタマイズ性
+  - point: 3
+    reason: Hooks機能による高い拡張性
   minus_points:
-    - point: -5
-      reason: BYOKモデルのため、タスクによってはAPI料金が高額になる可能性がある
-    - point: -3
-      reason: エージェントの能力を最大限に引き出すには習熟が必要で、学習コストが高い
-    - point: -2
-      reason: 公式ドキュメントやコミュニティが英語中心で、日本語の情報が少ない
+  - point: -5
+    reason: BYOKモデルのため、タスクによってはAPI料金が高額になる可能性がある
+  - point: -3
+    reason: エージェントの能力を最大限に引き出すには習熟が必要で、学習コストが高い
+  - point: -2
+    reason: 公式ドキュメントやコミュニティが英語中心で、日本語の情報が少ない
   summary: 高いカスタマイズ性とセキュリティを誇るが、コスト管理と学習曲線が課題となる上級者向けAIエージェント。
 links:
   github: https://github.com/cline/cline
@@ -51,14 +51,14 @@ links:
   documentation: https://docs.cline.bot/
 relationships:
   related_tools:
-    - Devin
-    - Cursor
-    - GitHub Copilot
-    - Windsurf
-    - Roo Code
-    - Visual Studio Code
-    - Model Context Protocol
-    - Agent Trace
+  - Devin
+  - Cursor
+  - GitHub Copilot
+  - Devin Desktop
+  - Roo Code
+  - Visual Studio Code
+  - Model Context Protocol
+  - Agent Trace
 ---
 
 # **Cline 調査レポート**

--- a/_reports/codex-app.md
+++ b/_reports/codex-app.md
@@ -8,39 +8,39 @@ official_site: https://developers.openai.com/codex/app
 date: '2026-03-19'
 last_updated: '2026-03-19'
 tags:
-- AI
-- エージェント
-- 自動化
-- 開発者ツール
+  - AI
+  - エージェント
+  - 自動化
+  - 開発者ツール
 description: Codexスレッドを並行して実行するためのフォーカスされたデスクトップ環境で、ワークツリーサポート、自動化、Git機能が組み込まれています。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: $20/月
   target_users:
-  - 開発者
-  - エンジニアチーム
+    - 開発者
+    - エンジニアチーム
   latest_highlight: デスクトップアプリの提供開始
   update_frequency: 高
 evaluation:
   score: 85
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 複数エージェントによる並行作業を容易にするワークツリー機能
-  - point: 5
-    reason: 組み込みターミナルやGit統合によりアプリ内で作業を完結可能
-  - point: 5
-    reason: スケジュール実行可能な自動化機能(Automations)のサポート
+    - point: 5
+      reason: 複数エージェントによる並行作業を容易にするワークツリー機能
+    - point: 5
+      reason: 組み込みターミナルやGit統合によりアプリ内で作業を完結可能
+    - point: 5
+      reason: スケジュール実行可能な自動化機能(Automations)のサポート
   minus_points: []
   summary: エージェントを使った開発タスクの管理・並行処理に特化しており、効率的なマルチタスク開発を実現する強力なツールです。
 relationships:
   related_tools:
-  - Cursor
-  - Devin Desktop
-  - GitHub Copilot
-  - Cline
-  - Codex cloud
+    - Cursor
+    - Devin Desktop
+    - GitHub Copilot
+    - Cline
+    - Codex cloud
 ---
 
 # **Codex app 調査レポート**

--- a/_reports/codex-app.md
+++ b/_reports/codex-app.md
@@ -8,39 +8,39 @@ official_site: https://developers.openai.com/codex/app
 date: '2026-03-19'
 last_updated: '2026-03-19'
 tags:
-  - AI
-  - エージェント
-  - 自動化
-  - 開発者ツール
+- AI
+- エージェント
+- 自動化
+- 開発者ツール
 description: Codexスレッドを並行して実行するためのフォーカスされたデスクトップ環境で、ワークツリーサポート、自動化、Git機能が組み込まれています。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: $20/月
   target_users:
-    - 開発者
-    - エンジニアチーム
+  - 開発者
+  - エンジニアチーム
   latest_highlight: デスクトップアプリの提供開始
   update_frequency: 高
 evaluation:
   score: 85
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 複数エージェントによる並行作業を容易にするワークツリー機能
-    - point: 5
-      reason: 組み込みターミナルやGit統合によりアプリ内で作業を完結可能
-    - point: 5
-      reason: スケジュール実行可能な自動化機能(Automations)のサポート
+  - point: 5
+    reason: 複数エージェントによる並行作業を容易にするワークツリー機能
+  - point: 5
+    reason: 組み込みターミナルやGit統合によりアプリ内で作業を完結可能
+  - point: 5
+    reason: スケジュール実行可能な自動化機能(Automations)のサポート
   minus_points: []
   summary: エージェントを使った開発タスクの管理・並行処理に特化しており、効率的なマルチタスク開発を実現する強力なツールです。
 relationships:
   related_tools:
-    - Cursor
-    - Windsurf
-    - GitHub Copilot
-    - Cline
-    - Codex cloud
+  - Cursor
+  - Devin Desktop
+  - GitHub Copilot
+  - Cline
+  - Codex cloud
 ---
 
 # **Codex app 調査レポート**

--- a/_reports/cursor.md
+++ b/_reports/cursor.md
@@ -8,56 +8,56 @@ official_site: https://cursor.com/
 date: '2025-10-19'
 last_updated: '2026-05-10'
 tags:
-- AI
-- IDE
-- エージェント
-- コーディング支援
-- 開発者ツール
+  - AI
+  - IDE
+  - エージェント
+  - コーディング支援
+  - 開発者ツール
 description: AIを第一に考えて作られたコードエディタ。VS Codeのフォークをベースに、コードベース全体を理解するAI機能が深く統合されている。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: $20/月
   target_users:
-  - 開発者
-  - AIエンジニア
+    - 開発者
+    - AIエンジニア
   latest_highlight: 2026年5月に「Security Reviewer」と「Vulnerability Scanner」のセキュリティ関連機能を追加
   update_frequency: 高
 evaluation:
   score: 88
   base_score: 70
   plus_points:
-  - point: 8
-    reason: VS Codeベースの優れたUXと、既存のキーバインドや拡張機能をそのまま利用できる点
-  - point: 7
-    reason: コードベース全体を理解し、ファイル横断でのコード生成・編集・リファクタリングが可能
-  - point: 5
-    reason: Multi-AgentやPlan Modeなど、単なる補完を超えた高度な自律エージェント機能
-  - point: 3
-    reason: CLI連携やデバッグモードなど、開発ワークフロー全体を支援する機能が継続的に追加されている
-  - point: 2
-    reason: 主要な最新LLMを選択して利用できる柔軟性
+    - point: 8
+      reason: VS Codeベースの優れたUXと、既存のキーバインドや拡張機能をそのまま利用できる点
+    - point: 7
+      reason: コードベース全体を理解し、ファイル横断でのコード生成・編集・リファクタリングが可能
+    - point: 5
+      reason: Multi-AgentやPlan Modeなど、単なる補完を超えた高度な自律エージェント機能
+    - point: 3
+      reason: CLI連携やデバッグモードなど、開発ワークフロー全体を支援する機能が継続的に追加されている
+    - point: 2
+      reason: 主要な最新LLMを選択して利用できる柔軟性
   minus_points:
-  - point: -3
-    reason: 競合のAIコーディング支援ツール（GitHub Copilot等）と比較して料金が高め
-  - point: -2
-    reason: AI機能の使用により、時折パフォーマンスが低下する場合があるとの報告
-  - point: -2
-    reason: 料金プランが細分化されており、最適なプランの選択がやや複雑
+    - point: -3
+      reason: 競合のAIコーディング支援ツール（GitHub Copilot等）と比較して料金が高め
+    - point: -2
+      reason: AI機能の使用により、時折パフォーマンスが低下する場合があるとの報告
+    - point: -2
+      reason: 料金プランが細分化されており、最適なプランの選択がやや複雑
   summary: VS Codeの操作性を維持しつつ強力なAI機能を統合した高機能エディタだが、価格体系とパフォーマンスが検討点となる。
 links:
   documentation: https://cursor.com/docs
 relationships:
   related_tools:
-  - Spec Kit
-  - GitHub Copilot
-  - Devin Desktop
-  - Cline
-  - Roo Code
-  - Visual Studio Code
-  - Devin
-  - Model Context Protocol
-  - Agent Trace
+    - Spec Kit
+    - GitHub Copilot
+    - Devin Desktop
+    - Cline
+    - Roo Code
+    - Visual Studio Code
+    - Devin
+    - Model Context Protocol
+    - Agent Trace
 ---
 
 # **Cursor 調査レポート**

--- a/_reports/cursor.md
+++ b/_reports/cursor.md
@@ -8,56 +8,56 @@ official_site: https://cursor.com/
 date: '2025-10-19'
 last_updated: '2026-05-10'
 tags:
-  - AI
-  - IDE
-  - エージェント
-  - コーディング支援
-  - 開発者ツール
+- AI
+- IDE
+- エージェント
+- コーディング支援
+- 開発者ツール
 description: AIを第一に考えて作られたコードエディタ。VS Codeのフォークをベースに、コードベース全体を理解するAI機能が深く統合されている。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: $20/月
   target_users:
-    - 開発者
-    - AIエンジニア
+  - 開発者
+  - AIエンジニア
   latest_highlight: 2026年5月に「Security Reviewer」と「Vulnerability Scanner」のセキュリティ関連機能を追加
   update_frequency: 高
 evaluation:
   score: 88
   base_score: 70
   plus_points:
-    - point: 8
-      reason: VS Codeベースの優れたUXと、既存のキーバインドや拡張機能をそのまま利用できる点
-    - point: 7
-      reason: コードベース全体を理解し、ファイル横断でのコード生成・編集・リファクタリングが可能
-    - point: 5
-      reason: Multi-AgentやPlan Modeなど、単なる補完を超えた高度な自律エージェント機能
-    - point: 3
-      reason: CLI連携やデバッグモードなど、開発ワークフロー全体を支援する機能が継続的に追加されている
-    - point: 2
-      reason: 主要な最新LLMを選択して利用できる柔軟性
+  - point: 8
+    reason: VS Codeベースの優れたUXと、既存のキーバインドや拡張機能をそのまま利用できる点
+  - point: 7
+    reason: コードベース全体を理解し、ファイル横断でのコード生成・編集・リファクタリングが可能
+  - point: 5
+    reason: Multi-AgentやPlan Modeなど、単なる補完を超えた高度な自律エージェント機能
+  - point: 3
+    reason: CLI連携やデバッグモードなど、開発ワークフロー全体を支援する機能が継続的に追加されている
+  - point: 2
+    reason: 主要な最新LLMを選択して利用できる柔軟性
   minus_points:
-    - point: -3
-      reason: 競合のAIコーディング支援ツール（GitHub Copilot等）と比較して料金が高め
-    - point: -2
-      reason: AI機能の使用により、時折パフォーマンスが低下する場合があるとの報告
-    - point: -2
-      reason: 料金プランが細分化されており、最適なプランの選択がやや複雑
+  - point: -3
+    reason: 競合のAIコーディング支援ツール（GitHub Copilot等）と比較して料金が高め
+  - point: -2
+    reason: AI機能の使用により、時折パフォーマンスが低下する場合があるとの報告
+  - point: -2
+    reason: 料金プランが細分化されており、最適なプランの選択がやや複雑
   summary: VS Codeの操作性を維持しつつ強力なAI機能を統合した高機能エディタだが、価格体系とパフォーマンスが検討点となる。
 links:
   documentation: https://cursor.com/docs
 relationships:
   related_tools:
-    - Spec Kit
-    - GitHub Copilot
-    - Windsurf
-    - Cline
-    - Roo Code
-    - Visual Studio Code
-    - Devin
-    - Model Context Protocol
-    - Agent Trace
+  - Spec Kit
+  - GitHub Copilot
+  - Devin Desktop
+  - Cline
+  - Roo Code
+  - Visual Studio Code
+  - Devin
+  - Model Context Protocol
+  - Agent Trace
 ---
 
 # **Cursor 調査レポート**
@@ -223,7 +223,7 @@ relationships:
 
 ### **16.1 機能比較表 (星取表)**
 
-| 機能カテゴリ | 機能項目 | 本ツール (Cursor) | GitHub Copilot | Windsurf | VS Code |
+| 機能カテゴリ | 機能項目 | 本ツール (Cursor) | GitHub Copilot | Devin Desktop | VS Code |
 |:---:|:---|:---:|:---:|:---:|:---:|
 | **基本機能** | エディタ統合 | ◎<br><small>完全統合</small> | ◯<br><small>拡張機能</small> | ◎<br><small>完全統合</small> | -<br><small>ベース</small> |
 | **カテゴリ特定** | コードベース理解 | ◎<br><small>RAG+インデックス</small> | △<br><small>限定的</small> | ◎<br><small>Cascade</small> | ×<br><small>なし</small> |
@@ -236,7 +236,7 @@ relationships:
 |---------|------|------|------|------------------|
 | **Cursor** | VS CodeベースのAIネイティブエディタ。 | 深い文脈理解、Composerによる強力な編集機能、既存VS Code環境との互換性。 | ベースのVS Code更新に追従するラグがある。独自の拡張機能ストアはない（VS Code用を使う）。 | コードベース全体にまたがる複雑なタスクをAIに任せたい場合。 |
 | **GitHub Copilot** | 各種エディタの拡張機能として提供。 | 導入が手軽、多くのエディタに対応、比較的安価。GitHubプラットフォームとの連携。 | エディタのUIそのものを変更できないため、統合体験はCursorに劣る場合がある。 | 既存のエディタ環境を変えたくない場合。GitHub中心の開発フローの場合。 |
-| **Windsurf** | ライブプレビューとCascadeエージェントを特徴とするAIエディタ。 | 直感的なプレビュー機能、強力なエージェント機能。 | コミュニティやエコシステムがまだ発展途上。 | フロントエンド開発などで即時プレビューを重視する場合。 |
+| **Devin Desktop** | ライブプレビューとCascadeエージェントを特徴とするAIエディタ。 | 直感的なプレビュー機能、強力なエージェント機能。 | コミュニティやエコシステムがまだ発展途上。 | フロントエンド開発などで即時プレビューを重視する場合。 |
 | **VS Code** | 世界で最も使われているコードエディタ。Cursorのベース。 | 無料、軽量、圧倒的な拡張機能数。 | AI機能は拡張機能に依存し、標準では搭載されていない。 | AI機能を必要としない、または自分で拡張機能を選んで環境構築したい場合。 |
 
 ## **17. 総評**

--- a/_reports/devin.md
+++ b/_reports/devin.md
@@ -8,55 +8,55 @@ official_site: https://devin.ai/
 date: '2026-01-27'
 last_updated: '2026-06-20'
 tags:
-  - AI
-  - エージェント
-  - コーディング支援
-  - 自動化
-  - 自律型
-  - 開発者ツール
+- AI
+- エージェント
+- コーディング支援
+- 自動化
+- 自律型
+- 開発者ツール
 description: 世界初の完全自律型AIソフトウェアエンジニア。自然言語の指示に基づき、ソフトウェア開発の計画、コーディング、デバッグ、テスト、デプロイまでを一貫して自律的に実行します。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: $20から
   target_users:
-    - 開発者
-    - スタートアップ
-    - プロダクトマネージャー
+  - 開発者
+  - スタートアップ
+  - プロダクトマネージャー
   latest_highlight: 2026年6月にMCP Marketplaceの拡張やGitLabネイティブ連携をリリース
   update_frequency: 高
 evaluation:
   score: 75
   base_score: 70
   plus_points:
-    - point: 8
-      reason: タスクの計画からデプロイまで一貫して実行できる自律性を持ち、独自のIDEや多数の連携機能を備えている。
-    - point: 5
-      reason: リリースノートから確認できるように、機能改善や新機能の追加が毎週のように行われており、開発が非常に活発である。
-    - point: 2
-      reason: プロトタイピングやWebスクレイピング等の特定タスクにおいて、高い評価を得ている。
+  - point: 8
+    reason: タスクの計画からデプロイまで一貫して実行できる自律性を持ち、独自のIDEや多数の連携機能を備えている。
+  - point: 5
+    reason: リリースノートから確認できるように、機能改善や新機能の追加が毎週のように行われており、開発が非常に活発である。
+  - point: 2
+    reason: プロトタイピングやWebスクレイピング等の特定タスクにおいて、高い評価を得ている。
   minus_points:
-    - point: -5
-      reason: レビューサイト等で、複雑なタスクにおける成功率が約15%と報告されており、信頼性に課題がある。
-    - point: -3
-      reason: Teamプランが月額$500と高価なことに加え、ACUベースの従量課金のためコストが想定以上になる可能性がある。
-    - point: -2
-      reason: UIやドキュメントは英語が基本であり、日本語での指示に対する精度は英語に劣る可能性がある。
+  - point: -5
+    reason: レビューサイト等で、複雑なタスクにおける成功率が約15%と報告されており、信頼性に課題がある。
+  - point: -3
+    reason: Teamプランが月額$500と高価なことに加え、ACUベースの従量課金のためコストが想定以上になる可能性がある。
+  - point: -2
+    reason: UIやドキュメントは英語が基本であり、日本語での指示に対する精度は英語に劣る可能性がある。
   summary: タスクの自律性は高いが成功率に課題があり、コストと信頼性のバランスを考慮した特定用途での導入が現実的。
 links:
   documentation: https://docs.devin.ai/
 relationships:
   children:
-    - DeepWiki
+  - DeepWiki
   related_tools:
-    - GitHub Copilot
-    - Cursor
-    - Windsurf
-    - OpenHands
-    - AutoGPT
-    - Agent Zero
-    - Manus
-    - Deep Agents
+  - GitHub Copilot
+  - Cursor
+  - Devin Desktop
+  - OpenHands
+  - AutoGPT
+  - Agent Zero
+  - Manus
+  - Deep Agents
 ---
 
 # **Devin 調査レポート**

--- a/_reports/devin.md
+++ b/_reports/devin.md
@@ -8,55 +8,55 @@ official_site: https://devin.ai/
 date: '2026-01-27'
 last_updated: '2026-06-20'
 tags:
-- AI
-- エージェント
-- コーディング支援
-- 自動化
-- 自律型
-- 開発者ツール
+  - AI
+  - エージェント
+  - コーディング支援
+  - 自動化
+  - 自律型
+  - 開発者ツール
 description: 世界初の完全自律型AIソフトウェアエンジニア。自然言語の指示に基づき、ソフトウェア開発の計画、コーディング、デバッグ、テスト、デプロイまでを一貫して自律的に実行します。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: $20から
   target_users:
-  - 開発者
-  - スタートアップ
-  - プロダクトマネージャー
+    - 開発者
+    - スタートアップ
+    - プロダクトマネージャー
   latest_highlight: 2026年6月にMCP Marketplaceの拡張やGitLabネイティブ連携をリリース
   update_frequency: 高
 evaluation:
   score: 75
   base_score: 70
   plus_points:
-  - point: 8
-    reason: タスクの計画からデプロイまで一貫して実行できる自律性を持ち、独自のIDEや多数の連携機能を備えている。
-  - point: 5
-    reason: リリースノートから確認できるように、機能改善や新機能の追加が毎週のように行われており、開発が非常に活発である。
-  - point: 2
-    reason: プロトタイピングやWebスクレイピング等の特定タスクにおいて、高い評価を得ている。
+    - point: 8
+      reason: タスクの計画からデプロイまで一貫して実行できる自律性を持ち、独自のIDEや多数の連携機能を備えている。
+    - point: 5
+      reason: リリースノートから確認できるように、機能改善や新機能の追加が毎週のように行われており、開発が非常に活発である。
+    - point: 2
+      reason: プロトタイピングやWebスクレイピング等の特定タスクにおいて、高い評価を得ている。
   minus_points:
-  - point: -5
-    reason: レビューサイト等で、複雑なタスクにおける成功率が約15%と報告されており、信頼性に課題がある。
-  - point: -3
-    reason: Teamプランが月額$500と高価なことに加え、ACUベースの従量課金のためコストが想定以上になる可能性がある。
-  - point: -2
-    reason: UIやドキュメントは英語が基本であり、日本語での指示に対する精度は英語に劣る可能性がある。
+    - point: -5
+      reason: レビューサイト等で、複雑なタスクにおける成功率が約15%と報告されており、信頼性に課題がある。
+    - point: -3
+      reason: Teamプランが月額$500と高価なことに加え、ACUベースの従量課金のためコストが想定以上になる可能性がある。
+    - point: -2
+      reason: UIやドキュメントは英語が基本であり、日本語での指示に対する精度は英語に劣る可能性がある。
   summary: タスクの自律性は高いが成功率に課題があり、コストと信頼性のバランスを考慮した特定用途での導入が現実的。
 links:
   documentation: https://docs.devin.ai/
 relationships:
   children:
-  - DeepWiki
+    - DeepWiki
   related_tools:
-  - GitHub Copilot
-  - Cursor
-  - Devin Desktop
-  - OpenHands
-  - AutoGPT
-  - Agent Zero
-  - Manus
-  - Deep Agents
+    - GitHub Copilot
+    - Cursor
+    - Devin Desktop
+    - OpenHands
+    - AutoGPT
+    - Agent Zero
+    - Manus
+    - Deep Agents
 ---
 
 # **Devin 調査レポート**

--- a/_reports/github-copilot-app.md
+++ b/_reports/github-copilot-app.md
@@ -8,35 +8,35 @@ official_site: https://github.com/github/app
 date: '2026-05-15'
 last_updated: '2026-05-15'
 tags:
-  - AI
-  - エージェント
-  - コーディング支援
-  - 生成AI
-  - 開発者ツール
-  - デスクトップアプリ
+- AI
+- エージェント
+- コーディング支援
+- 生成AI
+- 開発者ツール
+- デスクトップアプリ
 description: GitHub Copilot appは、エージェント主導の開発（agent-driven development）のために設計された、デスクトップアプリケーションです。並行作業やGitHub統合をひとつの場所にまとめます。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: Copilot Business/Enterprise または Pro+ サブスクリプションが必要
   target_users:
-    - 開発者
-    - DevOpsエンジニア
+  - 開発者
+  - DevOpsエンジニア
   latest_highlight: 2026年5月リリースの v0.2.4 にて、フォローアッププロンプトのキューイングやスキル連携が強化。
   update_frequency: 高
 evaluation:
   score: 83
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 複数のAIエージェントを並行して実行でき、開発のボトルネックを解消する
-    - point: 4
-      reason: GitHubのIssueやPRとネイティブに連携し、ライフサイクル全体を管理可能
-    - point: 4
-      reason: ターミナルやIDEを切り替えるコンテキストスイッチを削減する
+  - point: 5
+    reason: 複数のAIエージェントを並行して実行でき、開発のボトルネックを解消する
+  - point: 4
+    reason: GitHubのIssueやPRとネイティブに連携し、ライフサイクル全体を管理可能
+  - point: 4
+    reason: ターミナルやIDEを切り替えるコンテキストスイッチを削減する
   minus_points:
-    - point: 0
-      reason: ''
+  - point: 0
+    reason: ''
   summary: 複数のエージェントを指揮し、コーディングからPR作成までを一元管理できる次世代の開発環境。
 links:
   github: https://github.com/github/app
@@ -46,10 +46,10 @@ relationships:
   parent: GitHub Copilot
   children: []
   related_tools:
-    - GitHub Copilot CLI
-    - Cursor
-    - Windsurf
-    - Cline
+  - GitHub Copilot CLI
+  - Cursor
+  - Devin Desktop
+  - Cline
 ---
 
 # **GitHub Copilot app 調査レポート**

--- a/_reports/github-copilot-app.md
+++ b/_reports/github-copilot-app.md
@@ -8,35 +8,35 @@ official_site: https://github.com/github/app
 date: '2026-05-15'
 last_updated: '2026-05-15'
 tags:
-- AI
-- エージェント
-- コーディング支援
-- 生成AI
-- 開発者ツール
-- デスクトップアプリ
+  - AI
+  - エージェント
+  - コーディング支援
+  - 生成AI
+  - 開発者ツール
+  - デスクトップアプリ
 description: GitHub Copilot appは、エージェント主導の開発（agent-driven development）のために設計された、デスクトップアプリケーションです。並行作業やGitHub統合をひとつの場所にまとめます。
 quick_summary:
   has_free_plan: false
   is_oss: false
   starting_price: Copilot Business/Enterprise または Pro+ サブスクリプションが必要
   target_users:
-  - 開発者
-  - DevOpsエンジニア
+    - 開発者
+    - DevOpsエンジニア
   latest_highlight: 2026年5月リリースの v0.2.4 にて、フォローアッププロンプトのキューイングやスキル連携が強化。
   update_frequency: 高
 evaluation:
   score: 83
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 複数のAIエージェントを並行して実行でき、開発のボトルネックを解消する
-  - point: 4
-    reason: GitHubのIssueやPRとネイティブに連携し、ライフサイクル全体を管理可能
-  - point: 4
-    reason: ターミナルやIDEを切り替えるコンテキストスイッチを削減する
+    - point: 5
+      reason: 複数のAIエージェントを並行して実行でき、開発のボトルネックを解消する
+    - point: 4
+      reason: GitHubのIssueやPRとネイティブに連携し、ライフサイクル全体を管理可能
+    - point: 4
+      reason: ターミナルやIDEを切り替えるコンテキストスイッチを削減する
   minus_points:
-  - point: 0
-    reason: ''
+    - point: 0
+      reason: ''
   summary: 複数のエージェントを指揮し、コーディングからPR作成までを一元管理できる次世代の開発環境。
 links:
   github: https://github.com/github/app
@@ -46,10 +46,10 @@ relationships:
   parent: GitHub Copilot
   children: []
   related_tools:
-  - GitHub Copilot CLI
-  - Cursor
-  - Devin Desktop
-  - Cline
+    - GitHub Copilot CLI
+    - Cursor
+    - Devin Desktop
+    - Cline
 ---
 
 # **GitHub Copilot app 調査レポート**

--- a/_reports/github-copilot.md
+++ b/_reports/github-copilot.md
@@ -8,53 +8,53 @@ official_site: https://github.com/features/copilot
 date: '2026-01-17'
 last_updated: '2026-05-21'
 tags:
-  - AI
-  - エージェント
-  - コーディング支援
-  - 生成AI
-  - 開発者ツール
+- AI
+- エージェント
+- コーディング支援
+- 生成AI
+- 開発者ツール
 description: GitHub Copilotは、GPT-5やClaude 4.5などの最新モデルを搭載し、IDEやCLIでコーディング全般を支援するAIペアプログラマーです。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: 無料
   target_users:
-    - 開発者
-    - スタートアップ
-    - 大企業
+  - 開発者
+  - スタートアップ
+  - 大企業
   latest_highlight: 2026年5月にCopilot on WebやVS Code等でのモデル自動選択・アップデート、Gemini 3.5 Flashサポート等を追加
   update_frequency: 高
 evaluation:
   score: 84
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 無料プランがあり、個人開発者も手軽に利用開始できる
-    - point: 8
-      reason: GPT-5、Claude 4.5、Gemini 3.5 Flashなど、利用可能なAIモデルの選択肢が非常に豊富
-    - point: 6
-      reason: Copilot EditsやCLIエージェントなど、機能の進化が非常に速い
+  - point: 5
+    reason: 無料プランがあり、個人開発者も手軽に利用開始できる
+  - point: 8
+    reason: GPT-5、Claude 4.5、Gemini 3.5 Flashなど、利用可能なAIモデルの選択肢が非常に豊富
+  - point: 6
+    reason: Copilot EditsやCLIエージェントなど、機能の進化が非常に速い
   minus_points:
-    - point: -3
-      reason: 上位機能（Spark等）を含むPro+プランは月額$39と個人向けとしては高額
-    - point: -2
-      reason: 機能が多岐にわたるため、使いこなすまでの学習コストがやや高い
+  - point: -3
+    reason: 上位機能（Spark等）を含むPro+プランは月額$39と個人向けとしては高額
+  - point: -2
+    reason: 機能が多岐にわたるため、使いこなすまでの学習コストがやや高い
   summary: 無料プランからハイエンドなPro+まで幅広いニーズに対応し、常に最新モデルと機能を提供する業界標準ツール。
 links:
   documentation: https://docs.github.com/en/copilot
 relationships:
   parent: GitHub
   children:
-    - GitHub Copilot CLI
-    - GitHub Copilot app
+  - GitHub Copilot CLI
+  - GitHub Copilot app
   related_tools:
-    - Cursor
-    - Windsurf
-    - Cline
-    - Roo Code
-    - CodeRabbit
-    - Devin
-    - SHIFT DQS for リバースエンジニアリング
+  - Cursor
+  - Devin Desktop
+  - Cline
+  - Roo Code
+  - CodeRabbit
+  - Devin
+  - SHIFT DQS for リバースエンジニアリング
 ---
 
 # **GitHub Copilot 調査レポート**

--- a/_reports/github-copilot.md
+++ b/_reports/github-copilot.md
@@ -8,53 +8,53 @@ official_site: https://github.com/features/copilot
 date: '2026-01-17'
 last_updated: '2026-05-21'
 tags:
-- AI
-- エージェント
-- コーディング支援
-- 生成AI
-- 開発者ツール
+  - AI
+  - エージェント
+  - コーディング支援
+  - 生成AI
+  - 開発者ツール
 description: GitHub Copilotは、GPT-5やClaude 4.5などの最新モデルを搭載し、IDEやCLIでコーディング全般を支援するAIペアプログラマーです。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: 無料
   target_users:
-  - 開発者
-  - スタートアップ
-  - 大企業
+    - 開発者
+    - スタートアップ
+    - 大企業
   latest_highlight: 2026年5月にCopilot on WebやVS Code等でのモデル自動選択・アップデート、Gemini 3.5 Flashサポート等を追加
   update_frequency: 高
 evaluation:
   score: 84
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 無料プランがあり、個人開発者も手軽に利用開始できる
-  - point: 8
-    reason: GPT-5、Claude 4.5、Gemini 3.5 Flashなど、利用可能なAIモデルの選択肢が非常に豊富
-  - point: 6
-    reason: Copilot EditsやCLIエージェントなど、機能の進化が非常に速い
+    - point: 5
+      reason: 無料プランがあり、個人開発者も手軽に利用開始できる
+    - point: 8
+      reason: GPT-5、Claude 4.5、Gemini 3.5 Flashなど、利用可能なAIモデルの選択肢が非常に豊富
+    - point: 6
+      reason: Copilot EditsやCLIエージェントなど、機能の進化が非常に速い
   minus_points:
-  - point: -3
-    reason: 上位機能（Spark等）を含むPro+プランは月額$39と個人向けとしては高額
-  - point: -2
-    reason: 機能が多岐にわたるため、使いこなすまでの学習コストがやや高い
+    - point: -3
+      reason: 上位機能（Spark等）を含むPro+プランは月額$39と個人向けとしては高額
+    - point: -2
+      reason: 機能が多岐にわたるため、使いこなすまでの学習コストがやや高い
   summary: 無料プランからハイエンドなPro+まで幅広いニーズに対応し、常に最新モデルと機能を提供する業界標準ツール。
 links:
   documentation: https://docs.github.com/en/copilot
 relationships:
   parent: GitHub
   children:
-  - GitHub Copilot CLI
-  - GitHub Copilot app
+    - GitHub Copilot CLI
+    - GitHub Copilot app
   related_tools:
-  - Cursor
-  - Devin Desktop
-  - Cline
-  - Roo Code
-  - CodeRabbit
-  - Devin
-  - SHIFT DQS for リバースエンジニアリング
+    - Cursor
+    - Devin Desktop
+    - Cline
+    - Roo Code
+    - CodeRabbit
+    - Devin
+    - SHIFT DQS for リバースエンジニアリング
 ---
 
 # **GitHub Copilot 調査レポート**

--- a/_reports/google-antigravity.md
+++ b/_reports/google-antigravity.md
@@ -8,51 +8,52 @@ official_site: https://antigravity.google/
 date: '2026-02-28'
 last_updated: '2026-06-10'
 tags:
-  - AI
-  - 生成AI
-  - オープンソース
-  - テスト自動化
-  - エージェント
-  - IDE
-  - コーディング支援
-  - 開発者ツール
+- AI
+- 生成AI
+- オープンソース
+- テスト自動化
+- エージェント
+- IDE
+- コーディング支援
+- 開発者ツール
 description: AIを単なるツールではなく自律的なアクターとして活用する、エージェントファーストな新しい開発プラットフォーム。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: 無料
   target_users:
-    - 開発者
+  - 開発者
   latest_highlight: Antigravity 2.0のバグ修正やAntigravity IDE連携の強化など（v2.0.x）
   update_frequency: 高
 evaluation:
   score: 85
   base_score: 70
   plus_points:
-    - point: 8
-      reason: 複数のエージェントを非同期に並行して動作させ、それぞれがタスクを計画・実行・検証できる強力なAgent Manager機能
-    - point: 5
-      reason: VS Codeをフォークしており、既存の開発者に馴染みのあるEditor Viewを保持している
-    - point: 4
-      reason: Artifactsを用いたフィードバックループにより、レビューと軌道修正がGoogle Docsのように直感的に行える
-    - point: 3
-      reason: ブラウザと深く統合され、UIの変更やエンドツーエンドのテストを自律的に確認可能
+  - point: 8
+    reason: 複数のエージェントを非同期に並行して動作させ、それぞれがタスクを計画・実行・検証できる強力なAgent Manager機能
+  - point: 5
+    reason: VS Codeをフォークしており、既存の開発者に馴染みのあるEditor Viewを保持している
+  - point: 4
+    reason: Artifactsを用いたフィードバックループにより、レビューと軌道修正がGoogle Docsのように直感的に行える
+  - point: 3
+    reason: ブラウザと深く統合され、UIの変更やエンドツーエンドのテストを自律的に確認可能
   minus_points:
-    - point: -3
-      reason: AIエージェントに自律的にターミナルやブラウザを操作させることによるセキュリティ上の懸念事項やリスクへの対策（Allow List, Deny List等）の適切な運用が必要
-    - point: -2
-      reason: 新しいプレビュー版ツールであり、まだ成熟途上にある
+  - point: -3
+    reason: AIエージェントに自律的にターミナルやブラウザを操作させることによるセキュリティ上の懸念事項やリスクへの対策（Allow List, Deny
+      List等）の適切な運用が必要
+  - point: -2
+    reason: 新しいプレビュー版ツールであり、まだ成熟途上にある
   summary: 強力な自律型マルチエージェントオーケストレーションと、親しみやすいVS CodeベースのUIを融合させた、革新的な次世代AI開発プラットフォーム。
 links:
   documentation: https://antigravity.google/docs
 relationships:
   related_tools:
-    - Visual Studio Code
-    - Cursor
-    - Windsurf
+  - Visual Studio Code
+  - Cursor
+  - Devin Desktop
   parent: Gemini
   children:
-    - Antigravity CLI
+  - Antigravity CLI
 ---
 
 # **Google Antigravity 調査レポート**

--- a/_reports/google-antigravity.md
+++ b/_reports/google-antigravity.md
@@ -8,52 +8,51 @@ official_site: https://antigravity.google/
 date: '2026-02-28'
 last_updated: '2026-06-10'
 tags:
-- AI
-- 生成AI
-- オープンソース
-- テスト自動化
-- エージェント
-- IDE
-- コーディング支援
-- 開発者ツール
+  - AI
+  - 生成AI
+  - オープンソース
+  - テスト自動化
+  - エージェント
+  - IDE
+  - コーディング支援
+  - 開発者ツール
 description: AIを単なるツールではなく自律的なアクターとして活用する、エージェントファーストな新しい開発プラットフォーム。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: 無料
   target_users:
-  - 開発者
+    - 開発者
   latest_highlight: Antigravity 2.0のバグ修正やAntigravity IDE連携の強化など（v2.0.x）
   update_frequency: 高
 evaluation:
   score: 85
   base_score: 70
   plus_points:
-  - point: 8
-    reason: 複数のエージェントを非同期に並行して動作させ、それぞれがタスクを計画・実行・検証できる強力なAgent Manager機能
-  - point: 5
-    reason: VS Codeをフォークしており、既存の開発者に馴染みのあるEditor Viewを保持している
-  - point: 4
-    reason: Artifactsを用いたフィードバックループにより、レビューと軌道修正がGoogle Docsのように直感的に行える
-  - point: 3
-    reason: ブラウザと深く統合され、UIの変更やエンドツーエンドのテストを自律的に確認可能
+    - point: 8
+      reason: 複数のエージェントを非同期に並行して動作させ、それぞれがタスクを計画・実行・検証できる強力なAgent Manager機能
+    - point: 5
+      reason: VS Codeをフォークしており、既存の開発者に馴染みのあるEditor Viewを保持している
+    - point: 4
+      reason: Artifactsを用いたフィードバックループにより、レビューと軌道修正がGoogle Docsのように直感的に行える
+    - point: 3
+      reason: ブラウザと深く統合され、UIの変更やエンドツーエンドのテストを自律的に確認可能
   minus_points:
-  - point: -3
-    reason: AIエージェントに自律的にターミナルやブラウザを操作させることによるセキュリティ上の懸念事項やリスクへの対策（Allow List, Deny
-      List等）の適切な運用が必要
-  - point: -2
-    reason: 新しいプレビュー版ツールであり、まだ成熟途上にある
+    - point: -3
+      reason: AIエージェントに自律的にターミナルやブラウザを操作させることによるセキュリティ上の懸念事項やリスクへの対策（Allow List, Deny List等）の適切な運用が必要
+    - point: -2
+      reason: 新しいプレビュー版ツールであり、まだ成熟途上にある
   summary: 強力な自律型マルチエージェントオーケストレーションと、親しみやすいVS CodeベースのUIを融合させた、革新的な次世代AI開発プラットフォーム。
 links:
   documentation: https://antigravity.google/docs
 relationships:
   related_tools:
-  - Visual Studio Code
-  - Cursor
-  - Devin Desktop
+    - Visual Studio Code
+    - Cursor
+    - Devin Desktop
   parent: Gemini
   children:
-  - Antigravity CLI
+    - Antigravity CLI
 ---
 
 # **Google Antigravity 調査レポート**

--- a/_reports/kiro.md
+++ b/_reports/kiro.md
@@ -8,48 +8,48 @@ official_site: https://kiro.dev/
 date: '2026-02-20'
 last_updated: '2026-05-27'
 tags:
-  - AI
-  - IDE
-  - エージェント
-  - クラウド
-  - 開発者ツール
+- AI
+- IDE
+- エージェント
+- クラウド
+- 開発者ツール
 description: 自然言語から仕様書を生成し、自律エージェントが実装を行うスペック駆動開発型のAIネイティブIDE。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: 無料
   target_users:
-    - 開発者
-    - スタートアップ
-    - SaaS開発チーム
+  - 開発者
+  - スタートアップ
+  - SaaS開発チーム
   latest_highlight: 2026年5月にKiro Web（プレビュー）公開、Claude Opus 4.7対応、およびHIPAA準拠を発表
   update_frequency: 高
 evaluation:
   score: 82
   base_score: 70
   plus_points:
-    - point: 5
-      reason: スペック駆動開発による要件定義からの構造的な実装が可能
-    - point: 4
-      reason: AWSの信頼性とセキュリティ基準（SOC2等）に準拠
-    - point: 3
-      reason: VS Code互換で移行が容易
-    - point: 2
-      reason: 自律エージェント機能が強力でカスタマイズも可能
+  - point: 5
+    reason: スペック駆動開発による要件定義からの構造的な実装が可能
+  - point: 4
+    reason: AWSの信頼性とセキュリティ基準（SOC2等）に準拠
+  - point: 3
+    reason: VS Code互換で移行が容易
+  - point: 2
+    reason: 自律エージェント機能が強力でカスタマイズも可能
   minus_points:
-    - point: -1
-      reason: 日本語ドキュメントやUIがまだ英語中心
-    - point: -1
-      reason: クレジット制の従量課金がやや複雑
+  - point: -1
+    reason: 日本語ドキュメントやUIがまだ英語中心
+  - point: -1
+    reason: クレジット制の従量課金がやや複雑
   summary: AWS発の強力なAIネイティブIDE。スペック駆動開発という独自のアプローチで、実装だけでなく設計フェーズからAIが支援する点が革新的。
 relationships:
   related_tools:
-    - Cursor
-    - Amazon Q Developer
-    - Windsurf
-    - AWS Frontier Agents
-    - cc-sdd
-    - OpenSpec
+  - Cursor
+  - Amazon Q Developer
+  - Devin Desktop
+  - AWS Frontier Agents
+  - cc-sdd
+  - OpenSpec
   parent: GitKraken
 ---
 

--- a/_reports/kiro.md
+++ b/_reports/kiro.md
@@ -8,48 +8,48 @@ official_site: https://kiro.dev/
 date: '2026-02-20'
 last_updated: '2026-05-27'
 tags:
-- AI
-- IDE
-- エージェント
-- クラウド
-- 開発者ツール
+  - AI
+  - IDE
+  - エージェント
+  - クラウド
+  - 開発者ツール
 description: 自然言語から仕様書を生成し、自律エージェントが実装を行うスペック駆動開発型のAIネイティブIDE。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: 無料
   target_users:
-  - 開発者
-  - スタートアップ
-  - SaaS開発チーム
+    - 開発者
+    - スタートアップ
+    - SaaS開発チーム
   latest_highlight: 2026年5月にKiro Web（プレビュー）公開、Claude Opus 4.7対応、およびHIPAA準拠を発表
   update_frequency: 高
 evaluation:
   score: 82
   base_score: 70
   plus_points:
-  - point: 5
-    reason: スペック駆動開発による要件定義からの構造的な実装が可能
-  - point: 4
-    reason: AWSの信頼性とセキュリティ基準（SOC2等）に準拠
-  - point: 3
-    reason: VS Code互換で移行が容易
-  - point: 2
-    reason: 自律エージェント機能が強力でカスタマイズも可能
+    - point: 5
+      reason: スペック駆動開発による要件定義からの構造的な実装が可能
+    - point: 4
+      reason: AWSの信頼性とセキュリティ基準（SOC2等）に準拠
+    - point: 3
+      reason: VS Code互換で移行が容易
+    - point: 2
+      reason: 自律エージェント機能が強力でカスタマイズも可能
   minus_points:
-  - point: -1
-    reason: 日本語ドキュメントやUIがまだ英語中心
-  - point: -1
-    reason: クレジット制の従量課金がやや複雑
+    - point: -1
+      reason: 日本語ドキュメントやUIがまだ英語中心
+    - point: -1
+      reason: クレジット制の従量課金がやや複雑
   summary: AWS発の強力なAIネイティブIDE。スペック駆動開発という独自のアプローチで、実装だけでなく設計フェーズからAIが支援する点が革新的。
 relationships:
   related_tools:
-  - Cursor
-  - Amazon Q Developer
-  - Devin Desktop
-  - AWS Frontier Agents
-  - cc-sdd
-  - OpenSpec
+    - Cursor
+    - Amazon Q Developer
+    - Devin Desktop
+    - AWS Frontier Agents
+    - cc-sdd
+    - OpenSpec
   parent: GitKraken
 ---
 

--- a/_reports/model-context-protocol.md
+++ b/_reports/model-context-protocol.md
@@ -8,32 +8,32 @@ official_site: https://modelcontextprotocol.io/
 date: '2026-02-03'
 last_updated: '2026-04-19'
 tags:
-- AI
-- オープンソース
-- 開発者ツール
-- API
+  - AI
+  - オープンソース
+  - 開発者ツール
+  - API
 description: AIモデルと外部のデータ・ツールを接続するためのオープン標準プロトコル
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-  - 開発者
-  - AIエンジニア
+    - 開発者
+    - AIエンジニア
   latest_highlight: 2026年4月にメンテナー体制の拡充を発表、コミュニティ主導の開発が加速
   update_frequency: 高
 evaluation:
   score: 95
   base_score: 70
   plus_points:
-  - point: 10
-    reason: AIとツール間の接続を標準化し、個別実装の乱立を防ぐ画期的なプロトコル
-  - point: 5
-    reason: Anthropic主導で、Microsoft, Google等の主要プレイヤーも参画・対応が進んでいる
-  - point: 5
-    reason: オープンソースであり、誰でもサーバーやクライアントを開発可能
-  - point: 5
-    reason: セキュリティ（サンドボックス化）とユーザビリティを両立
+    - point: 10
+      reason: AIとツール間の接続を標準化し、個別実装の乱立を防ぐ画期的なプロトコル
+    - point: 5
+      reason: Anthropic主導で、Microsoft, Google等の主要プレイヤーも参画・対応が進んでいる
+    - point: 5
+      reason: オープンソースであり、誰でもサーバーやクライアントを開発可能
+    - point: 5
+      reason: セキュリティ（サンドボックス化）とユーザビリティを両立
   minus_points: []
   summary: AIアプリケーションのエコシステムを根底から変える、事実上の標準（デファクトスタンダード）となるプロトコル
 links:
@@ -42,18 +42,18 @@ links:
 relationships:
   parent: ''
   children:
-  - AWS MCP Servers
-  - Context7
-  - MCP Apps
-  - Microsoft Work IQ
+    - AWS MCP Servers
+    - Context7
+    - MCP Apps
+    - Microsoft Work IQ
   related_tools:
-  - Claude
-  - Cursor
-  - Devin Desktop
-  - Cline
-  - Agent Skills
-  - Mobile Next
-  - UI-TARS Desktop
+    - Claude
+    - Cursor
+    - Devin Desktop
+    - Cline
+    - Agent Skills
+    - Mobile Next
+    - UI-TARS Desktop
 ---
 
 # **Model Context Protocol (MCP) 調査レポート**

--- a/_reports/model-context-protocol.md
+++ b/_reports/model-context-protocol.md
@@ -8,32 +8,32 @@ official_site: https://modelcontextprotocol.io/
 date: '2026-02-03'
 last_updated: '2026-04-19'
 tags:
-  - AI
-  - オープンソース
-  - 開発者ツール
-  - API
+- AI
+- オープンソース
+- 開発者ツール
+- API
 description: AIモデルと外部のデータ・ツールを接続するためのオープン標準プロトコル
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-    - 開発者
-    - AIエンジニア
+  - 開発者
+  - AIエンジニア
   latest_highlight: 2026年4月にメンテナー体制の拡充を発表、コミュニティ主導の開発が加速
   update_frequency: 高
 evaluation:
   score: 95
   base_score: 70
   plus_points:
-    - point: 10
-      reason: AIとツール間の接続を標準化し、個別実装の乱立を防ぐ画期的なプロトコル
-    - point: 5
-      reason: Anthropic主導で、Microsoft, Google等の主要プレイヤーも参画・対応が進んでいる
-    - point: 5
-      reason: オープンソースであり、誰でもサーバーやクライアントを開発可能
-    - point: 5
-      reason: セキュリティ（サンドボックス化）とユーザビリティを両立
+  - point: 10
+    reason: AIとツール間の接続を標準化し、個別実装の乱立を防ぐ画期的なプロトコル
+  - point: 5
+    reason: Anthropic主導で、Microsoft, Google等の主要プレイヤーも参画・対応が進んでいる
+  - point: 5
+    reason: オープンソースであり、誰でもサーバーやクライアントを開発可能
+  - point: 5
+    reason: セキュリティ（サンドボックス化）とユーザビリティを両立
   minus_points: []
   summary: AIアプリケーションのエコシステムを根底から変える、事実上の標準（デファクトスタンダード）となるプロトコル
 links:
@@ -42,18 +42,18 @@ links:
 relationships:
   parent: ''
   children:
-    - AWS MCP Servers
-    - Context7
-    - MCP Apps
-    - Microsoft Work IQ
+  - AWS MCP Servers
+  - Context7
+  - MCP Apps
+  - Microsoft Work IQ
   related_tools:
-    - Claude
-    - Cursor
-    - Windsurf
-    - Cline
-    - Agent Skills
-    - Mobile Next
-    - UI-TARS Desktop
+  - Claude
+  - Cursor
+  - Devin Desktop
+  - Cline
+  - Agent Skills
+  - Mobile Next
+  - UI-TARS Desktop
 ---
 
 # **Model Context Protocol (MCP) 調査レポート**

--- a/_reports/openai-codex-cli.md
+++ b/_reports/openai-codex-cli.md
@@ -8,36 +8,36 @@ official_site: https://developers.openai.com/codex/cli
 date: '2026-03-19'
 last_updated: '2026-03-19'
 tags:
-- AI
-- CLI
-- エージェント
-- 自律型
-- 開発者ツール
+  - AI
+  - CLI
+  - エージェント
+  - 自律型
+  - 開発者ツール
 description: OpenAIのモデルを搭載し、ローカル環境でコードの読み取りや変更、コマンドの実行を自律的に行うオープンソースのコマンドラインAIエージェント
 quick_summary:
   has_free_plan: false
   is_oss: true
   starting_price: $20/月 (ChatGPT Plus等に内包)
   target_users:
-  - 開発者
-  - ソフトウェアエンジニア
+    - 開発者
+    - ソフトウェアエンジニア
   latest_highlight: GPT-5.4やGPT-5.3-Codexなどの最新推論モデルをターミナルで利用可能
   update_frequency: 高
 evaluation:
   score: 83
   base_score: 70
   plus_points:
-  - point: 5
-    reason: オープンソース(Rust実装)であり、高速かつ効率的に動作
-  - point: 4
-    reason: 最新のOpenAI推論モデル(o4, GPT-5.4等)をローカルCLIで直接利用可能
-  - point: 4
-    reason: MCP(Model Context Protocol)をサポートし、外部ツールとの連携が強力
-  - point: 3
-    reason: ローカルのコードレビューやWeb検索などの多様な機能を内蔵
+    - point: 5
+      reason: オープンソース(Rust実装)であり、高速かつ効率的に動作
+    - point: 4
+      reason: 最新のOpenAI推論モデル(o4, GPT-5.4等)をローカルCLIで直接利用可能
+    - point: 4
+      reason: MCP(Model Context Protocol)をサポートし、外部ツールとの連携が強力
+    - point: 3
+      reason: ローカルのコードレビューやWeb検索などの多様な機能を内蔵
   minus_points:
-  - point: -3
-    reason: 利用にはChatGPT Plusなどの有料プランまたはAPIキーが必要（単体無料ではない）
+    - point: -3
+      reason: 利用にはChatGPT Plusなどの有料プランまたはAPIキーが必要（単体無料ではない）
   summary: ターミナルから直接最新のOpenAIモデルにアクセスし、ローカル環境で強力な自律的開発支援を受けられる優秀なCLIツール
 links:
   github: https://github.com/openai/codex
@@ -47,13 +47,13 @@ links:
 relationships:
   parent: ChatGPT
   related_tools:
-  - Cline
-  - Cursor
-  - Devin Desktop
-  - Symphony
-  - SkillsMP
-  - Agentic Workflows
-  - Grok CLI
+    - Cline
+    - Cursor
+    - Devin Desktop
+    - Symphony
+    - SkillsMP
+    - Agentic Workflows
+    - Grok CLI
 ---
 
 # **OpenAI Codex CLI 調査レポート**

--- a/_reports/openai-codex-cli.md
+++ b/_reports/openai-codex-cli.md
@@ -8,36 +8,36 @@ official_site: https://developers.openai.com/codex/cli
 date: '2026-03-19'
 last_updated: '2026-03-19'
 tags:
-  - AI
-  - CLI
-  - エージェント
-  - 自律型
-  - 開発者ツール
+- AI
+- CLI
+- エージェント
+- 自律型
+- 開発者ツール
 description: OpenAIのモデルを搭載し、ローカル環境でコードの読み取りや変更、コマンドの実行を自律的に行うオープンソースのコマンドラインAIエージェント
 quick_summary:
   has_free_plan: false
   is_oss: true
   starting_price: $20/月 (ChatGPT Plus等に内包)
   target_users:
-    - 開発者
-    - ソフトウェアエンジニア
+  - 開発者
+  - ソフトウェアエンジニア
   latest_highlight: GPT-5.4やGPT-5.3-Codexなどの最新推論モデルをターミナルで利用可能
   update_frequency: 高
 evaluation:
   score: 83
   base_score: 70
   plus_points:
-    - point: 5
-      reason: オープンソース(Rust実装)であり、高速かつ効率的に動作
-    - point: 4
-      reason: 最新のOpenAI推論モデル(o4, GPT-5.4等)をローカルCLIで直接利用可能
-    - point: 4
-      reason: MCP(Model Context Protocol)をサポートし、外部ツールとの連携が強力
-    - point: 3
-      reason: ローカルのコードレビューやWeb検索などの多様な機能を内蔵
+  - point: 5
+    reason: オープンソース(Rust実装)であり、高速かつ効率的に動作
+  - point: 4
+    reason: 最新のOpenAI推論モデル(o4, GPT-5.4等)をローカルCLIで直接利用可能
+  - point: 4
+    reason: MCP(Model Context Protocol)をサポートし、外部ツールとの連携が強力
+  - point: 3
+    reason: ローカルのコードレビューやWeb検索などの多様な機能を内蔵
   minus_points:
-    - point: -3
-      reason: 利用にはChatGPT Plusなどの有料プランまたはAPIキーが必要（単体無料ではない）
+  - point: -3
+    reason: 利用にはChatGPT Plusなどの有料プランまたはAPIキーが必要（単体無料ではない）
   summary: ターミナルから直接最新のOpenAIモデルにアクセスし、ローカル環境で強力な自律的開発支援を受けられる優秀なCLIツール
 links:
   github: https://github.com/openai/codex
@@ -47,13 +47,13 @@ links:
 relationships:
   parent: ChatGPT
   related_tools:
-    - Cline
-    - Cursor
-    - Windsurf
-    - Symphony
-    - SkillsMP
-    - Agentic Workflows
-    - Grok CLI
+  - Cline
+  - Cursor
+  - Devin Desktop
+  - Symphony
+  - SkillsMP
+  - Agentic Workflows
+  - Grok CLI
 ---
 
 # **OpenAI Codex CLI 調査レポート**

--- a/_reports/openspec.md
+++ b/_reports/openspec.md
@@ -8,32 +8,32 @@ official_site: https://openspec.dev/
 date: '2026-03-11'
 last_updated: '2026-07-01'
 tags:
-  - AIコーディングアシスタント
-  - オープンソース
-  - ドキュメンテーション
+- AIコーディングアシスタント
+- オープンソース
+- ドキュメンテーション
 description: AIコーディングアシスタントのための軽量な仕様駆動型フレームワーク
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-    - 開発者
-    - AIエージェント利用者
+  - 開発者
+  - AIエージェント利用者
   latest_highlight: Stores（ベータ版）による仕様と変更のシンプルな管理モデルが導入
   update_frequency: 高
 evaluation:
   score: 80
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 20以上の主要なAIコーディングアシスタントと統合できる高い汎用性
-    - point: 3
-      reason: 完全無料のオープンソースツール
-    - point: 4
-      reason: コードベースと仕様書のズレを防ぐSpec-Drivenなアプローチ
+  - point: 5
+    reason: 20以上の主要なAIコーディングアシスタントと統合できる高い汎用性
+  - point: 3
+    reason: 完全無料のオープンソースツール
+  - point: 4
+    reason: コードベースと仕様書のズレを防ぐSpec-Drivenなアプローチ
   minus_points:
-    - point: -2
-      reason: テキスト（Markdown）ベースのため、視覚的なプランニングツールを好むユーザーには不向きな場合がある
+  - point: -2
+    reason: テキスト（Markdown）ベースのため、視覚的なプランニングツールを好むユーザーには不向きな場合がある
   summary: AIコーディングアシスタントの文脈を保持し、仕様ドリブンな開発を強力に支援する軽量ツール
 links:
   github: https://github.com/Fission-AI/OpenSpec
@@ -42,12 +42,12 @@ links:
   documentation: https://github.com/Fission-AI/OpenSpec/blob/main/docs/getting-started.md
 relationships:
   related_tools:
-    - GitHub Copilot
-    - Claude Code
-    - Cursor
-    - Windsurf
-    - Spec Kit
-    - Kiro
+  - GitHub Copilot
+  - Claude Code
+  - Cursor
+  - Devin Desktop
+  - Spec Kit
+  - Kiro
 ---
 
 # **OpenSpec 調査レポート**

--- a/_reports/openspec.md
+++ b/_reports/openspec.md
@@ -8,32 +8,32 @@ official_site: https://openspec.dev/
 date: '2026-03-11'
 last_updated: '2026-07-01'
 tags:
-- AIコーディングアシスタント
-- オープンソース
-- ドキュメンテーション
+  - AIコーディングアシスタント
+  - オープンソース
+  - ドキュメンテーション
 description: AIコーディングアシスタントのための軽量な仕様駆動型フレームワーク
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-  - 開発者
-  - AIエージェント利用者
+    - 開発者
+    - AIエージェント利用者
   latest_highlight: Stores（ベータ版）による仕様と変更のシンプルな管理モデルが導入
   update_frequency: 高
 evaluation:
   score: 80
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 20以上の主要なAIコーディングアシスタントと統合できる高い汎用性
-  - point: 3
-    reason: 完全無料のオープンソースツール
-  - point: 4
-    reason: コードベースと仕様書のズレを防ぐSpec-Drivenなアプローチ
+    - point: 5
+      reason: 20以上の主要なAIコーディングアシスタントと統合できる高い汎用性
+    - point: 3
+      reason: 完全無料のオープンソースツール
+    - point: 4
+      reason: コードベースと仕様書のズレを防ぐSpec-Drivenなアプローチ
   minus_points:
-  - point: -2
-    reason: テキスト（Markdown）ベースのため、視覚的なプランニングツールを好むユーザーには不向きな場合がある
+    - point: -2
+      reason: テキスト（Markdown）ベースのため、視覚的なプランニングツールを好むユーザーには不向きな場合がある
   summary: AIコーディングアシスタントの文脈を保持し、仕様ドリブンな開発を強力に支援する軽量ツール
 links:
   github: https://github.com/Fission-AI/OpenSpec
@@ -42,12 +42,12 @@ links:
   documentation: https://github.com/Fission-AI/OpenSpec/blob/main/docs/getting-started.md
 relationships:
   related_tools:
-  - GitHub Copilot
-  - Claude Code
-  - Cursor
-  - Devin Desktop
-  - Spec Kit
-  - Kiro
+    - GitHub Copilot
+    - Claude Code
+    - Cursor
+    - Devin Desktop
+    - Spec Kit
+    - Kiro
 ---
 
 # **OpenSpec 調査レポート**

--- a/_reports/roocode.md
+++ b/_reports/roocode.md
@@ -8,37 +8,37 @@ official_site: https://roocode.com/
 date: '2026-02-25'
 last_updated: '2026-06-07'
 tags:
-  - AI
-  - VS Code
-  - CLI
-  - エージェント
-  - オープンソース
+- AI
+- VS Code
+- CLI
+- エージェント
+- オープンソース
 description: VS Code拡張機能およびCLIとして動作する、オープンソースのAIソフトウェアエンジニアリングツール。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料 (BYOK)
   target_users:
-    - 開発者
-    - エンジニアリングチーム
-    - スタートアップ
+  - 開発者
+  - エンジニアリングチーム
+  - スタートアップ
   latest_highlight: 2026年5月にコミュニティ主導への移行を発表、GPT-5.5やClaude Opus 4.7など最新モデルへの対応を拡充（v3.53.0）
   update_frequency: 高
 evaluation:
   score: 86
   base_score: 70
   plus_points:
-    - point: 5
-      reason: 完全なモデル非依存（BYOK）で、最新モデル（GPT-5.5, Claude Opus 4.7等）を即座に利用可能
-    - point: 5
-      reason: 強力なコミュニティによるオープンソースプロジェクトとしての透明性と高いカスタマイズ性
-    - point: 4
-      reason: CLI対応やスラッシュコマンドなど、多様なワークフローに統合可能な柔軟性
-    - point: 3
-      reason: ロール別モード（Code, Architect, Debug）による深いコンテキスト理解と自律実行
+  - point: 5
+    reason: 完全なモデル非依存（BYOK）で、最新モデル（GPT-5.5, Claude Opus 4.7等）を即座に利用可能
+  - point: 5
+    reason: 強力なコミュニティによるオープンソースプロジェクトとしての透明性と高いカスタマイズ性
+  - point: 4
+    reason: CLI対応やスラッシュコマンドなど、多様なワークフローに統合可能な柔軟性
+  - point: 3
+    reason: ロール別モード（Code, Architect, Debug）による深いコンテキスト理解と自律実行
   minus_points:
-    - point: -1
-      reason: クラウドサービスのサンセットに伴い、機能の一部がローカル拡張機能やCLIに集約
+  - point: -1
+    reason: クラウドサービスのサンセットに伴い、機能の一部がローカル拡張機能やCLIに集約
   summary: 開発チームがRoomoteに移行しコミュニティ主導となったが、最先端モデルとCLIへの対応で強力なローカル環境アシスタントとして進化を続けている。
 links:
   github: https://github.com/RooCodeInc/Roo-Code
@@ -47,13 +47,13 @@ links:
   documentation: https://docs.roocode.com/
 relationships:
   related_tools:
-    - Cline
-    - Cursor
-    - GitHub Copilot
-    - Windsurf
-    - Claude Code
-    - Visual Studio Code
-    - Devin
+  - Cline
+  - Cursor
+  - GitHub Copilot
+  - Devin Desktop
+  - Claude Code
+  - Visual Studio Code
+  - Devin
 ---
 
 # **Roo Code 調査レポート**

--- a/_reports/roocode.md
+++ b/_reports/roocode.md
@@ -8,37 +8,37 @@ official_site: https://roocode.com/
 date: '2026-02-25'
 last_updated: '2026-06-07'
 tags:
-- AI
-- VS Code
-- CLI
-- エージェント
-- オープンソース
+  - AI
+  - VS Code
+  - CLI
+  - エージェント
+  - オープンソース
 description: VS Code拡張機能およびCLIとして動作する、オープンソースのAIソフトウェアエンジニアリングツール。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料 (BYOK)
   target_users:
-  - 開発者
-  - エンジニアリングチーム
-  - スタートアップ
+    - 開発者
+    - エンジニアリングチーム
+    - スタートアップ
   latest_highlight: 2026年5月にコミュニティ主導への移行を発表、GPT-5.5やClaude Opus 4.7など最新モデルへの対応を拡充（v3.53.0）
   update_frequency: 高
 evaluation:
   score: 86
   base_score: 70
   plus_points:
-  - point: 5
-    reason: 完全なモデル非依存（BYOK）で、最新モデル（GPT-5.5, Claude Opus 4.7等）を即座に利用可能
-  - point: 5
-    reason: 強力なコミュニティによるオープンソースプロジェクトとしての透明性と高いカスタマイズ性
-  - point: 4
-    reason: CLI対応やスラッシュコマンドなど、多様なワークフローに統合可能な柔軟性
-  - point: 3
-    reason: ロール別モード（Code, Architect, Debug）による深いコンテキスト理解と自律実行
+    - point: 5
+      reason: 完全なモデル非依存（BYOK）で、最新モデル（GPT-5.5, Claude Opus 4.7等）を即座に利用可能
+    - point: 5
+      reason: 強力なコミュニティによるオープンソースプロジェクトとしての透明性と高いカスタマイズ性
+    - point: 4
+      reason: CLI対応やスラッシュコマンドなど、多様なワークフローに統合可能な柔軟性
+    - point: 3
+      reason: ロール別モード（Code, Architect, Debug）による深いコンテキスト理解と自律実行
   minus_points:
-  - point: -1
-    reason: クラウドサービスのサンセットに伴い、機能の一部がローカル拡張機能やCLIに集約
+    - point: -1
+      reason: クラウドサービスのサンセットに伴い、機能の一部がローカル拡張機能やCLIに集約
   summary: 開発チームがRoomoteに移行しコミュニティ主導となったが、最先端モデルとCLIへの対応で強力なローカル環境アシスタントとして進化を続けている。
 links:
   github: https://github.com/RooCodeInc/Roo-Code
@@ -47,13 +47,13 @@ links:
   documentation: https://docs.roocode.com/
 relationships:
   related_tools:
-  - Cline
-  - Cursor
-  - GitHub Copilot
-  - Devin Desktop
-  - Claude Code
-  - Visual Studio Code
-  - Devin
+    - Cline
+    - Cursor
+    - GitHub Copilot
+    - Devin Desktop
+    - Claude Code
+    - Visual Studio Code
+    - Devin
 ---
 
 # **Roo Code 調査レポート**

--- a/_reports/rtk.md
+++ b/_reports/rtk.md
@@ -44,7 +44,7 @@ relationships:
   related_tools:
     - claude-code
     - cursor
-    - windsurf
+    - Devin Desktop
     - cline
     - GitHub Copilot CLI
 ---
@@ -108,7 +108,7 @@ relationships:
   rtk init -g
   ```
 
-  ※他にもCursor(`--agent cursor`)、Windsurf(`--agent windsurf`)、Cline(`--agent cline`)などに対応したオプションがある。
+  ※他にもCursor(`--agent cursor`)、Devin Desktop (旧 Windsurf)(`--agent windsurf`)、Cline(`--agent cline`)などに対応したオプションがある。
 
 * **クイックスタート**:
   AIツールを再起動後、通常のコマンドを実行すると透過的にRTKが適用される。
@@ -153,7 +153,7 @@ relationships:
 ### **10.1 API・外部サービス連携**
 
 * **API**: ツール自体はCLIだが、設定ファイルによるカスタマイズが可能。
-* **外部サービス連携**: 12種類の主要なAIコーディングエージェント（Claude Code, Cursor, Windsurf, Cline, Copilot CLI等）とシームレスに連携。
+* **外部サービス連携**: 12種類の主要なAIコーディングエージェント（Claude Code, Cursor, Devin Desktop, Cline, Copilot CLI等）とシームレスに連携。
 
 ### **10.2 技術スタックとの相性**
 
@@ -221,6 +221,6 @@ relationships:
 * **総合的な評価**:
   AIコーディングツールを利用する際の最大の課題の一つである「高額なAPIトークン利用コスト」を、透過的かつ劇的に削減してくれる画期的なツール。導入障壁が極めて低く、非常に実用的。
 * **推奨されるチームやプロジェクト**:
-  Claude Code、Cursor、WindsurfなどのAIコーディングアシスタントを日常的に活用しているすべての開発者・開発チーム。特に、API利用料が従量課金となっている場合に強い効果を発揮する。
+  Claude Code、Cursor、Devin DesktopなどのAIコーディングアシスタントを日常的に活用しているすべての開発者・開発チーム。特に、API利用料が従量課金となっている場合に強い効果を発揮する。
 * **選択時のポイント**:
   AIツールの利用コストに課題を感じている場合、他に有力な対抗馬がないため第一選択肢となる。環境構築の手間もほぼ無いため、導入しない手はないと言える。

--- a/_reports/vscode.md
+++ b/_reports/vscode.md
@@ -8,36 +8,36 @@ official_site: https://code.visualstudio.com/
 date: '2026-02-08'
 last_updated: '2026-05-07'
 tags:
-  - AI
-  - IDE
-  - オープンソース
-  - 開発者ツール
+- AI
+- IDE
+- オープンソース
+- 開発者ツール
 description: Microsoftが開発した、無料で高機能なオープンソースのコードエディタ。豊富な拡張機能により、あらゆる言語での開発に対応し、AIによるコーディング支援も強力です。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-    - 開発者
-    - Webデザイナー
-    - 学生
+  - 開発者
+  - Webデザイナー
+  - 学生
   latest_highlight: 2026年5月にエージェントとブラウザのスムーズな連携機能を追加
   update_frequency: 高
 evaluation:
   score: 95
   base_score: 70
   plus_points:
-    - point: 10
-      reason: 圧倒的な機能性、拡張性、パフォーマンスを無料で提供しており、開発者ツールのデファクトスタンダードとなっている
-    - point: 8
-      reason: GitHub CopilotをはじめとするAI機能の統合が強力で、開発体験を大幅に向上させる
-    - point: 5
-      reason: クロスプラットフォーム対応で、ドキュメントも充実しており、導入のハードルが非常に低い
-    - point: 5
-      reason: 活発なコミュニティと毎月のアップデートにより、常に進化を続けている
+  - point: 10
+    reason: 圧倒的な機能性、拡張性、パフォーマンスを無料で提供しており、開発者ツールのデファクトスタンダードとなっている
+  - point: 8
+    reason: GitHub CopilotをはじめとするAI機能の統合が強力で、開発体験を大幅に向上させる
+  - point: 5
+    reason: クロスプラットフォーム対応で、ドキュメントも充実しており、導入のハードルが非常に低い
+  - point: 5
+    reason: 活発なコミュニティと毎月のアップデートにより、常に進化を続けている
   minus_points:
-    - point: -3
-      reason: 高機能な反面、多すぎる拡張機能や設定項目が初学者を混乱させる可能性がある
+  - point: -3
+    reason: 高機能な反面、多すぎる拡張機能や設定項目が初学者を混乱させる可能性がある
   summary: 現代の開発に必須のツールであり、機能、拡張性、AI連携の全てにおいて最高水準のエディタ。
 links:
   github: https://github.com/microsoft/vscode
@@ -46,14 +46,14 @@ links:
   documentation: https://code.visualstudio.com/docs
 relationships:
   related_tools:
-    - Cursor
-    - GitHub Copilot
-    - IntelliJ IDEA
-    - Windsurf
-    - Cline
-    - Delphi
-    - Eclipse IDE
-    - Android Studio
+  - Cursor
+  - GitHub Copilot
+  - IntelliJ IDEA
+  - Devin Desktop
+  - Cline
+  - Delphi
+  - Eclipse IDE
+  - Android Studio
 ---
 
 # **Visual Studio Code 調査レポート**

--- a/_reports/vscode.md
+++ b/_reports/vscode.md
@@ -8,36 +8,36 @@ official_site: https://code.visualstudio.com/
 date: '2026-02-08'
 last_updated: '2026-05-07'
 tags:
-- AI
-- IDE
-- オープンソース
-- 開発者ツール
+  - AI
+  - IDE
+  - オープンソース
+  - 開発者ツール
 description: Microsoftが開発した、無料で高機能なオープンソースのコードエディタ。豊富な拡張機能により、あらゆる言語での開発に対応し、AIによるコーディング支援も強力です。
 quick_summary:
   has_free_plan: true
   is_oss: true
   starting_price: 無料
   target_users:
-  - 開発者
-  - Webデザイナー
-  - 学生
+    - 開発者
+    - Webデザイナー
+    - 学生
   latest_highlight: 2026年5月にエージェントとブラウザのスムーズな連携機能を追加
   update_frequency: 高
 evaluation:
   score: 95
   base_score: 70
   plus_points:
-  - point: 10
-    reason: 圧倒的な機能性、拡張性、パフォーマンスを無料で提供しており、開発者ツールのデファクトスタンダードとなっている
-  - point: 8
-    reason: GitHub CopilotをはじめとするAI機能の統合が強力で、開発体験を大幅に向上させる
-  - point: 5
-    reason: クロスプラットフォーム対応で、ドキュメントも充実しており、導入のハードルが非常に低い
-  - point: 5
-    reason: 活発なコミュニティと毎月のアップデートにより、常に進化を続けている
+    - point: 10
+      reason: 圧倒的な機能性、拡張性、パフォーマンスを無料で提供しており、開発者ツールのデファクトスタンダードとなっている
+    - point: 8
+      reason: GitHub CopilotをはじめとするAI機能の統合が強力で、開発体験を大幅に向上させる
+    - point: 5
+      reason: クロスプラットフォーム対応で、ドキュメントも充実しており、導入のハードルが非常に低い
+    - point: 5
+      reason: 活発なコミュニティと毎月のアップデートにより、常に進化を続けている
   minus_points:
-  - point: -3
-    reason: 高機能な反面、多すぎる拡張機能や設定項目が初学者を混乱させる可能性がある
+    - point: -3
+      reason: 高機能な反面、多すぎる拡張機能や設定項目が初学者を混乱させる可能性がある
   summary: 現代の開発に必須のツールであり、機能、拡張性、AI連携の全てにおいて最高水準のエディタ。
 links:
   github: https://github.com/microsoft/vscode
@@ -46,14 +46,14 @@ links:
   documentation: https://code.visualstudio.com/docs
 relationships:
   related_tools:
-  - Cursor
-  - GitHub Copilot
-  - IntelliJ IDEA
-  - Devin Desktop
-  - Cline
-  - Delphi
-  - Eclipse IDE
-  - Android Studio
+    - Cursor
+    - GitHub Copilot
+    - IntelliJ IDEA
+    - Devin Desktop
+    - Cline
+    - Delphi
+    - Eclipse IDE
+    - Android Studio
 ---
 
 # **Visual Studio Code 調査レポート**

--- a/_reports/windsurf.md
+++ b/_reports/windsurf.md
@@ -1,72 +1,74 @@
 ---
-title: Windsurf 調査レポート
-tool_name: Windsurf
-tool_reading: ウィンドサーフ
+title: Devin Desktop 調査レポート
+tool_name: Devin Desktop
+tool_reading: デヴィン デスクトップ / ウィンドサーフ
 category: AIエディタ/IDE
 developer: Cognition, Inc.
 official_site: https://windsurf.com/
 date: '2025-10-21'
-last_updated: '2026-03-15'
+last_updated: '2026-07-08'
 tags:
-  - AI
-  - エージェント
-  - コーディング支援
-  - 生成AI
-  - 開発者ツール
+- AI
+- エージェント
+- コーディング支援
+- 生成AI
+- 開発者ツール
 description: Windsurfは、開発者がフロー状態を維持できるように構築された、最も直感的なAIコーディング体験を提供するツールです。
 quick_summary:
   has_free_plan: true
   is_oss: false
-  starting_price: $15/月
+  starting_price: $20/月
   target_users:
-    - 開発者
-    - スタートアップ
-    - 大企業
-  latest_highlight: 2026年3月にv1.9577系をリリース、Jupyter NotebookやCascade機能のパフォーマンス向上など
+  - 開発者
+  - スタートアップ
+  - 大企業
+  latest_highlight: 2026年7月にv3.4.27をリリース。2026年6月にWindsurfからDevin Desktopに名称変更。
   update_frequency: 高
 evaluation:
-  score: 90
+  score: 91
   base_score: 70
   plus_points:
-    - point: 8
-      reason: Cascadeエージェントやライブプレビューなど、競合より優れた独自機能が豊富
-    - point: 5
-      reason: 40以上のIDEに対応しており、既存の開発環境に導入しやすい
-    - point: 5
-      reason: SOC 2やFedRAMP Highなど高いセキュリティ基準を満たしている
-    - point: 5
-      reason: 新LLMの迅速な統合や独自機能開発など、アップデートが非常に活発
+  - point: 8
+    reason: Cascadeエージェントやライブプレビューなど、競合より優れた独自機能が豊富
+  - point: 5
+    reason: 40以上のIDEに対応しており、既存の開発環境に導入しやすい
+  - point: 5
+    reason: SOC 2やFedRAMP Highなど高いセキュリティ基準を満たしている
+  - point: 5
+    reason: 新LLMの迅速な統合や独自機能開発など、アップデートが非常に活発
+  - point: 1
+    reason: Devin CloudやDevin Localエージェントによる柔軟で強力な環境連携の追加
   minus_points:
-    - point: -3
-      reason: G2レビューでドキュメントやコミュニティがまだ発展途上との指摘がある
+  - point: -3
+    reason: G2レビューでドキュメントやコミュニティがまだ発展途上との指摘がある
   summary: 豊富な独自機能と高いセキュリティを両立し、活発な開発が続く先進的なAIコードエディタ。
 links:
   documentation: https://docs.windsurf.com/
 relationships:
   related_tools:
-    - Kiro
-    - Visual Studio Code
-    - Cursor
-    - GitHub Copilot
-    - Cline
-    - Roo Code
-    - Claude Code
-    - Devin
-    - Aqua Voice
+  - Kiro
+  - Visual Studio Code
+  - Cursor
+  - GitHub Copilot
+  - Cline
+  - Roo Code
+  - Claude Code
+  - Devin
+  - Aqua Voice
 ---
 
 # **Windsurf 調査レポート**
 
 ## **1. 基本情報**
 
-* **ツール名**: Windsurf
-* **ツールの読み方**: ウィンドサーフ
+* **ツール名**: Devin Desktop (旧 Windsurf)
+* **ツールの読み方**: デヴィン デスクトップ / ウィンドサーフ
 * **開発元**: Cognition, Inc.
 * **公式サイト**: [https://windsurf.com/](https://windsurf.com/)
 * **関連リンク**:
   * ドキュメント: [https://docs.windsurf.com/](https://docs.windsurf.com/)
 * **カテゴリ**: AIコードエディタ
-* **概要**: Windsurfは、開発者とそのチームがフロー状態を維持できるように構築された、最も直感的なAIコーディング体験を提供するツールです。独自のAIネイティブIDEのほか、既存のIDE（VS Code, JetBrainsなど40以上）と連携するプラグインも提供しています。Cognition, Inc.（Devinの開発元）によって開発・提供されています。
+* **概要**: Devin Desktop (旧 Windsurf) は、開発者とそのチームがフロー状態を維持できるように構築された、最も直感的なAIコーディング体験を提供するツールです。独自のAIネイティブIDEのほか、既存のIDE（VS Code, JetBrainsなど40以上）と連携するプラグインも提供しています。Cognition, Inc.（Devinの開発元）によって開発・提供されています。
 
 ## **2. 目的と主な利用シーン**
 
@@ -85,6 +87,9 @@ relationships:
 
 ## **3. 主要機能**
 
+* **自律エージェント機能 (Devin Cloud / Devin Local)**: クラウド上で自律的に動作するDevinや、ローカル環境で動作するDevin LocalエージェントをIDEから直接利用可能。
+* **Arena Mode**: 複数のAIモデルを並行して実行し、結果を比較して最適なものを選択できるモード。
+* **Plan Mode**: コーディングを開始する前に詳細な実装計画を作成し、エージェントと共有できる機能。
 * **Cascade**: コードベースを深く理解し、コンテキストに応じたコード生成や修正を行うAIエージェント。Memories機能によりプロジェクトの重要な情報を記憶する。
 * **AIコード補完 (Tab)**: 複数行にわたるコードの提案や、オープンソースコードでトレーニングされたモデルによる自動補完。
 * **ライブプレビュー**: IDE内でコードのWebプレビューを直接表示し、要素をクリックして修正を指示できる。
@@ -208,6 +213,17 @@ relationships:
 
 ## **15. 直近半年のアップデート情報**
 
+* **2026-07-07**: v3.4.27リリース。自律モードでのdiff表示の問題を修正。
+* **2026-07-04**: v3.4.22リリース。スペースでの新しいセッション、チャットからの画像コピー、エージェントモードのデフォルト化など。Devin Localでは編集の差分レビュー、/mcpコマンドなどが追加。
+* **2026-06-23**: v3.3.18 / v3.2.28リリース。ACU使用量の表示、MCPレジストリキャッシュの起動時ウォームアップなど。
+* **2026-06-16**: v3.2.16リリース。Devin Localプラグインシステムのプレビュー、サブエージェントの直接MCP呼び出しなど。
+* **2026-06-10**: v3.1.7リリース。Agent/Editorモードの切り替えをスムーズに。Devin Localへの名称変更など。
+* **2026-06-02**: v3.0.12リリース。Windsurfから**Devin Desktop**へ正式に名称変更。
+* **2026-05-06**: v2.2.17リリース。Devin ReviewとQuick Review機能を追加。
+* **2026-04-29**: v2.1.29リリース。Devin for TerminalとWindsurf内のDevin Localエージェントを追加。
+* **2026-04-15**: v2.0.44リリース。**Windsurf 2.0**として、Devin CloudエージェントをIDEに統合し、Agent Command Centerを追加。
+* **2026-04-06**: v1.9600.38リリース。Adaptiveモデルルーターを導入し、タスクに最適なモデルを自動選択。
+* **2026-01-30**: v1.9544.24リリース。複数のモデルを比較できるArena Modeと、詳細な計画を作成するPlan Modeを導入。
 * **2026-03-09**: v1.9577.24リリース。Jupyter Notebookのパフォーマンス向上、Cascade UIレンダリングの改善、モデル価格変更の通知機能などを追加。
 * **2026-02-12**: v1.9552.21リリース。Plan ModeからCode Modeへの自動切り替え機能、Linux ARM64クライアントの正式サポート、Devinサービスキー認証のサポートなどを追加。
 * **2026-02-04**: v1.9544.35リリース。Arena ModeのFast ArenaおよびHybrid Arenaで`GPT-5.3-Codex-Spark`モデルが利用可能に。
@@ -218,13 +234,13 @@ relationships:
 * **2025-10-29**: 高速なエージェントモデル`SWE-1.5`を導入。
 * **2025-10-16**: SWE-grepを活用した`Fast Context`サブエージェントを導入し、関連コードの検索速度が最大20倍向上。
 
-(出典: [Windsurf Blog](https://windsurf.com/blog), [Changelog](https://windsurf.com/changelog))
+(出典: [Windsurf Blog](https://windsurf.com/blog), [Changelog](https://docs.devin.ai/desktop/changelog))
 
 ## **16. 類似ツールとの比較**
 
 ### **16.1 機能比較表 (星取表)**
 
-| 機能カテゴリ | 機能項目 | 本ツール (Windsurf) | Cursor | GitHub Copilot | Devin |
+| 機能カテゴリ | 機能項目 | 本ツール (Devin Desktop) | Cursor | GitHub Copilot | Devin |
 |:---:|:---|:---:|:---:|:---:|:---:|
 | **基本機能** | コード補完 | ◎<br><small>Tab補完が高速</small> | ◎<br><small>文脈理解が深い</small> | ◎<br><small>安定性が高い</small> | △<br><small>自律実行がメイン</small> |
 | **カテゴリ特定** | エージェント機能 | ◎<br><small>Cascade</small> | ◎<br><small>Agent Mode</small> | △<br><small>Chatがメイン</small> | ◎<br><small>完全自律型</small> |
@@ -235,7 +251,7 @@ relationships:
 
 | ツール名 | 特徴 | 強み | 弱み | 選択肢となるケース |
 |---------|------|------|------|------------------|
-| **Windsurf** | AIネイティブIDEとプラグインの両方を提供。Cascadeエージェントが強力。 | 既存のIDE環境を維持できる柔軟性。ライブプレビュー機能。高いセキュリティ基準。 | コミュニティやドキュメントがまだ発展途上。 | 既存の環境を変えずに強力なAIエージェントを導入したい場合。セキュリティ要件が厳しい場合。 |
+| **Devin Desktop** | AIネイティブIDEとプラグインの両方を提供。Cascadeエージェントが強力。 | 既存のIDE環境を維持できる柔軟性。ライブプレビュー機能。高いセキュリティ基準。 | コミュニティやドキュメントがまだ発展途上。 | 既存の環境を変えずに強力なAIエージェントを導入したい場合。セキュリティ要件が厳しい場合。 |
 | **Cursor** | VS CodeフォークのAI専用エディタ。 | コードベース全体の深い理解。AIとのシームレスな統合体験。 | 専用エディタへの移行が必要。 | 完全にAI中心の開発体験を求め、エディタ移行も厭わない場合。 |
 | **GitHub Copilot** | 最も普及しているAIコーディング支援ツール。 | 圧倒的なユーザー数と安定性。GitHubとの深い連携。 | 自律的なエージェント機能や深いコード理解では競合に劣る場合がある。 | 安定性と信頼性を重視し、標準的な補完機能を求める場合。 |
 | **Devin** | 完全自律型AIソフトウェアエンジニア。 | タスクの計画から実行までを自律的に行う能力。 | コストが高く、複雑なタスクの成功率に課題がある。 | 開発タスクそのものをAIに委任したい場合（プロトタイピング等）。 |
@@ -243,14 +259,14 @@ relationships:
 ## **17. 総評**
 
 * **総合的な評価**:
-  * Windsurfは、AIによる強力なコード生成・支援機能と、開発者の既存のワークフローを尊重する柔軟性を両立させた、非常にバランスの取れたAIコーディング支援ツールである。特に、コードベース全体を理解する「Cascade」エージェントや、直感的な「ライブプレビュー」機能は、競合に対する明確な優位性と言える。Cognition社による開発体制となり、Devinとの連携や技術共有が進んでいる点も大きな強みである。SOC 2 Type IIやFedRAMP Highといった高いセキュリティ基準を満たしており、エンタープライズでの利用にも適している。
+  * Devin Desktop (旧 Windsurf) は、AIによる強力なコード生成・支援機能と、開発者の既存のワークフローを尊重する柔軟性を両立させた、非常にバランスの取れたAIコーディング支援ツールである。特に、コードベース全体を理解する「Cascade」エージェントや、直感的な「ライブプレビュー」機能は、競合に対する明確な優位性と言える。Cognition社による開発体制となり、Devinとの連携や技術共有が進んでいる点も大きな強みである。SOC 2 Type IIやFedRAMP Highといった高いセキュリティ基準を満たしており、エンタープライズでの利用にも適している。
 * **推奨されるチームやプロジェクト**:
   * 新規・既存を問わず、AIの力を活用して開発速度を向上させたいあらゆる開発チーム。
   * 特に、フロントエンド開発の比重が高いプロジェクトでは、ライブプレビュー機能が大きな効果を発揮する。
   * VS CodeやJetBrainsなど、既存の開発環境を変えずにAI支援を導入したいチーム。
   * 高いセキュリティやコンプライアンスが求められるエンタープライズ環境。
 * **選択時のポイント**:
-  * 既存IDEとの連携、高度なAIエージェント機能、セキュリティを重視するならWindsurfが最適。
+  * 既存IDEとの連携、高度なAIエージェント機能、セキュリティを重視するならDevin Desktopが最適。
   * AI中心の新しい開発体験を求めるならCursor。
   * 安定性と実績を重視し、主にコード補完機能を利用したいならGitHub Copilot。
   * タスクそのものを委任したいならDevin。

--- a/_reports/windsurf.md
+++ b/_reports/windsurf.md
@@ -8,53 +8,53 @@ official_site: https://windsurf.com/
 date: '2025-10-21'
 last_updated: '2026-07-08'
 tags:
-- AI
-- エージェント
-- コーディング支援
-- 生成AI
-- 開発者ツール
+  - AI
+  - エージェント
+  - コーディング支援
+  - 生成AI
+  - 開発者ツール
 description: Windsurfは、開発者がフロー状態を維持できるように構築された、最も直感的なAIコーディング体験を提供するツールです。
 quick_summary:
   has_free_plan: true
   is_oss: false
   starting_price: $20/月
   target_users:
-  - 開発者
-  - スタートアップ
-  - 大企業
+    - 開発者
+    - スタートアップ
+    - 大企業
   latest_highlight: 2026年7月にv3.4.27をリリース。2026年6月にWindsurfからDevin Desktopに名称変更。
   update_frequency: 高
 evaluation:
   score: 91
   base_score: 70
   plus_points:
-  - point: 8
-    reason: Cascadeエージェントやライブプレビューなど、競合より優れた独自機能が豊富
-  - point: 5
-    reason: 40以上のIDEに対応しており、既存の開発環境に導入しやすい
-  - point: 5
-    reason: SOC 2やFedRAMP Highなど高いセキュリティ基準を満たしている
-  - point: 5
-    reason: 新LLMの迅速な統合や独自機能開発など、アップデートが非常に活発
-  - point: 1
-    reason: Devin CloudやDevin Localエージェントによる柔軟で強力な環境連携の追加
+    - point: 8
+      reason: Cascadeエージェントやライブプレビューなど、競合より優れた独自機能が豊富
+    - point: 5
+      reason: 40以上のIDEに対応しており、既存の開発環境に導入しやすい
+    - point: 5
+      reason: SOC 2やFedRAMP Highなど高いセキュリティ基準を満たしている
+    - point: 5
+      reason: 新LLMの迅速な統合や独自機能開発など、アップデートが非常に活発
+    - point: 1
+      reason: Devin CloudやDevin Localエージェントによる柔軟で強力な環境連携の追加
   minus_points:
-  - point: -3
-    reason: G2レビューでドキュメントやコミュニティがまだ発展途上との指摘がある
+    - point: -3
+      reason: G2レビューでドキュメントやコミュニティがまだ発展途上との指摘がある
   summary: 豊富な独自機能と高いセキュリティを両立し、活発な開発が続く先進的なAIコードエディタ。
 links:
   documentation: https://docs.windsurf.com/
 relationships:
   related_tools:
-  - Kiro
-  - Visual Studio Code
-  - Cursor
-  - GitHub Copilot
-  - Cline
-  - Roo Code
-  - Claude Code
-  - Devin
-  - Aqua Voice
+    - Kiro
+    - Visual Studio Code
+    - Cursor
+    - GitHub Copilot
+    - Cline
+    - Roo Code
+    - Claude Code
+    - Devin
+    - Aqua Voice
 ---
 
 # **Windsurf 調査レポート**


### PR DESCRIPTION
Updates the Windsurf report based on latest information, effectively identifying the rebranding to Devin Desktop and correctly propagating that rename across the entire corpus of reports in `related_tools` and comparison tables. Link checking confirmed ok.

---
*PR created automatically by Jules for task [5105847697588572531](https://jules.google.com/task/5105847697588572531) started by @aegisfleet*