### PR TITLE
fix: remove empty links from reports frontmatter

### DIFF
--- a/_reports/hurikaeri-jp.md
+++ b/_reports/hurikaeri-jp.md
@@ -33,11 +33,6 @@ evaluation:
       reason: すべて無料で利用可能であり、日本語の情報として極めて価値が高い
   minus_points: []
   summary: ふりかえりの導入からマンネリ打破まで、チームの課題解決に直結する実践的な知見が詰まったナレッジポータル。
-links:
-  github: ''
-  deepwiki: ''
-  codewiki: ''
-  documentation: ''
 relationships:
   parent: ''
   children: []

--- a/_reports/officecli.md
+++ b/_reports/officecli.md
@@ -35,7 +35,6 @@ evaluation:
   summary: AIエージェントがOfficeドキュメントを直接操作するための強力なツール。オープンソースでクロスプラットフォーム対応。
 links:
   github: https://github.com/iOfficeAI/OfficeCLI
-  deepwiki: ''
   codewiki: https://codewiki.google/github.com/iOfficeAI/OfficeCLI
   documentation: https://github.com/iOfficeAI/OfficeCLI/wiki
 relationships:


### PR DESCRIPTION
Removed empty fields (like `github: ''`, `deepwiki: ''`, etc.) from the `links:` section in the frontmatter of `_reports/hurikaeri-jp.md` and `_reports/officecli.md`. Empty fields evaluate to truthy in Liquid, which generates broken links (empty `href`) on the compiled pages.

---
*PR created automatically by Jules for task [186034234955718701](https://jules.google.com/task/186034234955718701) started by @aegisfleet*