### PR TITLE
chore: organize category tags (2026-07-18)

### DIFF
--- a/_reports/camera-camera-camera.md
+++ b/_reports/camera-camera-camera.md
@@ -2,7 +2,7 @@
 title: Camera Camera Camera 調査レポート
 tool_name: Camera Camera Camera
 tool_reading: カメラ カメラ カメラ
-category: コミュニケーション
+category: 3D/VTuber
 developer: Trippy
 official_site: https://camera-camera-camera.com/
 date: '2026-07-18'

--- a/_reports/line-harness.md
+++ b/_reports/line-harness.md
@@ -2,7 +2,7 @@
 title: LINE Harness 調査レポート
 tool_name: LINE Harness
 tool_reading: ラインハーネス
-category: CRM
+category: CRM/マーケティング
 developer: AIエージェント株式会社 / 野田修一 (Shudesu)
 official_site: https://shudesu.github.io/line-harness-oss/
 date: '2026-07-18'

--- a/_reports/open-code-review.md
+++ b/_reports/open-code-review.md
@@ -2,7 +2,7 @@
 title: Open Code Review 調査レポート
 tool_name: Open Code Review
 tool_reading: オープンコードレビュー
-category: AIコーディング支援
+category: AIコードレビュー
 developer: Alibaba Group
 official_site: https://alibaba.github.io/open-code-review/
 date: '2026-06-07'


### PR DESCRIPTION
This PR organizes category tags as of 2026-07-18 according to the rules defined in `task-organizing-category-tags.md`.

- Fixed undefined category `CRM` by changing it to `CRM/マーケティング`.
- Fixed undefined category `コミュニケーション` by changing it to `3D/VTuber`.
- Moved `Open Code Review` from `AIコーディング支援` to `AIコードレビュー` as it's specifically focused on code review.
- Checked `package-lock.json` and ensured no unrelated changes were included.
- Checked `categories.yml` synchronization and confirmed no changes are required since target categories already existed and the removed ones were previously undefined.

---
*PR created automatically by Jules for task [7812441878408405886](https://jules.google.com/task/7812441878408405886) started by @aegisfleet*