### PR TITLE
chore: Reorganize and re-classify report categories

### DIFF
--- a/_reports/agent-trace.md
+++ b/_reports/agent-trace.md
@@ -2,7 +2,7 @@
 title: Agent Trace 調査レポート
 tool_name: Agent Trace
 tool_reading: エージェントトレース
-category: AIエージェントフレームワーク
+category: 監視/可観測性
 developer: オープンコミュニティ (Cursor主導)
 official_site: https://agent-trace.dev/
 date: '2026-03-10'

--- a/_reports/apm.md
+++ b/_reports/apm.md
@@ -1,5 +1,5 @@
 ---
-category: AIエージェントフレームワーク
+category: パッケージ管理
 date: '2026-04-16'
 description: AIエージェントのコンテキスト（指示、プロンプト、スキル等）を管理・共有するためのオープンソースのパッケージマネージャー
 developer: Microsoft

--- a/_reports/aws-cli.md
+++ b/_reports/aws-cli.md
@@ -2,7 +2,7 @@
 title: AWS CLI 調査レポート
 tool_name: AWS CLI
 tool_reading: エーダブリューエス シーエルアイ
-category: インフラ/サーバー管理
+category: ターミナル/CLIツール
 developer: Amazon Web Services
 official_site: https://aws.amazon.com/jp/cli/
 date: '2026-04-18'

--- a/_reports/firebase-cli.md
+++ b/_reports/firebase-cli.md
@@ -2,7 +2,7 @@
 title: Firebase CLI 調査レポート
 tool_name: Firebase CLI
 tool_reading: ファイアベース・シーエルアイ
-category: インフラ/サーバー管理
+category: ターミナル/CLIツール
 developer: Google
 official_site: https://firebase.google.com/docs/cli
 date: '2026-04-18'

--- a/_reports/kong-ai-gateway.md
+++ b/_reports/kong-ai-gateway.md
@@ -2,7 +2,7 @@
 title: Kong AI Gateway 調査レポート
 tool_name: Kong AI Gateway
 tool_reading: コング エーアイ ゲートウェイ
-category: インフラ/サーバー管理
+category: AIゲートウェイ
 developer: Kong Inc.
 official_site: https://konghq.com/products/kong-ai-gateway
 date: '2026-06-22'

--- a/_reports/vibevoice.md
+++ b/_reports/vibevoice.md
@@ -2,7 +2,7 @@
 title: VibeVoice 調査レポート
 tool_name: VibeVoice
 tool_reading: バイブボイス
-category: 動画編集/配信
+category: AI音声/音楽生成
 developer: Microsoft
 official_site: https://microsoft.github.io/VibeVoice/
 date: '2026-04-26'


### PR DESCRIPTION
This PR cleans up the categories for several markdown reports in `_reports/`. Due to their unique use cases, these tools were in categories that caused them to be "split candidates". I reassigned them to their appropriate existing categories to lower the counts in those bloated categories while keeping the taxonomy clean.

---
*PR created automatically by Jules for task [5297826927259489530](https://jules.google.com/task/5297826927259489530) started by @aegisfleet*