### PR TITLE
docs: update Irodori-TTS report with v3 updates and VoiceDesign

### DIFF
--- a/_reports/irodori-tts.md
+++ b/_reports/irodori-tts.md
@@ -6,7 +6,7 @@ category: AI音声/音楽生成
 developer: Aratako
 official_site: https://github.com/Aratako/Irodori-TTS
 date: '2026-03-20'
-last_updated: '2026-03-20'
+last_updated: '2026-07-19'
 tags:
   - AI
   - 音声合成
@@ -21,7 +21,7 @@ quick_summary:
     - 開発者
     - 研究者
     - クリエイター
-  latest_highlight: Irodori-TTS-500MモデルがHugging Faceで公開
+  latest_highlight: Irodori-TTS-500M-v3モデルおよびVoiceDesignモデルの公開
   update_frequency: 低
 evaluation:
   score: 82
@@ -40,7 +40,7 @@ evaluation:
 links:
   github: https://github.com/Aratako/Irodori-TTS
   deepwiki: https://deepwiki.com/Aratako/Irodori-TTS
-  documentation: https://huggingface.co/Aratako/Irodori-TTS-500M
+  documentation: https://huggingface.co/Aratako/Irodori-TTS-500M-v3
 relationships:
   related_tools: []
 ---
@@ -55,10 +55,10 @@ relationships:
 * **公式サイト**: [https://github.com/Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 * **関連リンク**:
   * GitHub: [https://github.com/Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
-  * Hugging Face Model Card: [https://huggingface.co/Aratako/Irodori-TTS-500M](https://huggingface.co/Aratako/Irodori-TTS-500M)
-  * Demo Space: [https://huggingface.co/spaces/Aratako/Irodori-TTS-500M-Demo](https://huggingface.co/spaces/Aratako/Irodori-TTS-500M-Demo)
+  * Hugging Face Model Card: [https://huggingface.co/Aratako/Irodori-TTS-500M-v3](https://huggingface.co/Aratako/Irodori-TTS-500M-v3) | [VoiceDesign](https://huggingface.co/Aratako/Irodori-TTS-600M-v3-VoiceDesign)
+  * Demo Space: [https://huggingface.co/spaces/Aratako/Irodori-TTS-500M-v3-Demo](https://huggingface.co/spaces/Aratako/Irodori-TTS-500M-v3-Demo) | [VoiceDesign Demo](https://huggingface.co/spaces/Aratako/Irodori-TTS-600M-v3-VoiceDesign-Demo)
 * **カテゴリ**: 動画/メディア / 音声合成
-* **概要**: Irodori-TTSは、Rectified Flow Diffusion Transformer (RF-DiT) アーキテクチャをベースにした日本語テキスト音声合成（TTS）モデルです。連続的なDACVAE潜在変数を用いており、少量の参照音声からのゼロショットボイスクローニングや、入力テキストに絵文字を埋め込むことでのスタイル・効果音制御に対応しています。
+* **概要**: Irodori-TTSは、Rectified Flow Diffusion Transformer (RF-DiT) アーキテクチャをベースにした日本語テキスト音声合成（TTS）モデルです。連続的なDACVAE潜在変数を用いており、少量の参照音声からのゼロショットボイスクローニングや、入力テキストに絵文字を埋め込むことでのスタイル・効果音制御に対応しています。v3モデルではテキスト・参照音声・キャプションの3ブランチ条件付けをサポートするVoiceDesign機能や、自動長予測機能が追加されています。
 
 ## **2. 目的と主な利用シーン**
 
@@ -73,31 +73,60 @@ relationships:
 
 * **Flow Matching TTS**: 連続的なDACVAE潜在変数に対するRectified Flow Diffusion Transformerを用いた高品質な音声生成。
 * **Zero-shot Voice Cloning**: 短い参照音声（リファレンスオーディオ）を用意するだけで、その声質を模倣した音声を生成。
+* **Multi-modal Voice Design**: v3 VoiceDesignモデルにて、テキスト、参照音声、キャプションテキストの3ブランチ条件付けに対応し、声のアイデンティティとスタイル/感情のきめ細かな制御が可能。
 * **Emoji-based Style Control**: 入力テキストに特定の絵文字（例: 😭、🤧）を挿入することで、話し方のスタイルや感情、さらには効果音を制御可能。
+* **Automatic Duration Prediction**: v3ベースおよびVoiceDesignモデルでは、出力の長さを自動予測するDuration Predictorを統合。
+* **Speaker Inversion**: ベースモデルを凍結したまま、ターゲットの音声から再利用可能な話者埋め込み（Speaker Embedding）トークンを学習・推論する機能をサポート。
+* **Automatic Watermarking**: 生成された音声には、SilentCipherを利用した自動的な電子透かし（Watermarking）を適用。
 * **Multi-GPU Training**: `uv run torchrun`、勾配蓄積、bf16混合精度、Weights & Biasesを用いた分散学習をサポート。
-* **Flexible Inference**: CLI、Gradio Web UI、およびHugging Face Hubのチェックポイントを用いた推論に対応。
+* **PEFT LoRA Fine-Tuning**: 公開済みチェックポイントに対するパラメータ効率の高い微調整（LoRA）をサポート。
 
-## **4. 開始手順・セットアップ**
+## **4. 動作原理・システム構成**
+
+* **アーキテクチャ**: ローカルファーストで動作する、Flow MatchingベースのTTSモデル (Rectified Flow Diffusion Transformer: RF-DiT)。
+* **主要コンポーネントとデータフロー**:
+  * **Text Encoder**: 事前学習済みのLLMトークナイザから初期化されたテキスト埋め込みに対し、Self-attention + SwiGLU層（RoPE付き）を通して処理。
+  * **Reference Latent Encoder**: 話者のアイデンティティ条件付けのため、参照音声からDACVAE潜在変数を抽出。
+  * **Caption Encoder (VoiceDesignのみ)**: スタイルや感情を制御するキャプションテキストをエンコード。
+  * **Diffusion Transformer**: 低ランクAdaLN（適応型レイヤー正規化）やSwiGLU MLPを備えたジョイントアテンションDiTブロックを用いて、連続的な潜在変数を生成。
+  * **Duration Predictor (v3以降)**: 生成される出力の長さを自動予測。
+* **特筆すべき要素技術**:
+  * **DACVAE**: 音声波形を32次元の連続的な潜在変数（Semantic-DACVAE-Japanese-32dim）として表現し、高品質な48kHz音声の再構築を実現。
+  * **SilentCipher**: 生成された音声に対する電子透かし埋め込み機能。
+
+## **5. 開始手順・セットアップ**
 
 * **前提条件**:
   * Python環境
   * `uv`（Pythonパッケージマネージャー）
-  * CUDA対応GPU（推奨）、またはmacOS (MPS) / CPU
+  * CUDA対応GPU（推奨）、または AMD ROCm, Intel XPU, macOS (MPS) / CPU
 * **インストール/導入**:
 
   ```bash
   git clone https://github.com/Aratako/Irodori-TTS.git
   cd Irodori-TTS
-  uv sync
+
+  # NVIDIA CUDA 12.8環境の場合
+  uv sync --extra cu128
+
+  # AMD ROCmの場合
+  # uv sync --extra rocm
+
+  # Intel XPUの場合
+  # uv sync --extra xpu
+
+  # CPUのみ、またはmacOSの場合
+  # uv sync --extra cpu
   ```
 
 * **初期設定**:
   * 必要なモデルのチェックポイントは推論時にHugging Face Hubから自動でダウンロード可能です。
+  * PyTorchバックエンドを指定して同期した後は、`uv run --no-sync` を使用してコマンドを実行します。
 * **クイックスタート (CLI 推論)**:
 
   ```bash
-  uv run python infer.py \
-    --hf-checkpoint Aratako/Irodori-TTS-500M \
+  uv run --no-sync python infer.py \
+    --hf-checkpoint Aratako/Irodori-TTS-500M-v3 \
     --text "今日はいい天気ですね。" \
     --no-ref \
     --output-wav outputs/sample.wav
@@ -109,19 +138,19 @@ relationships:
   uv run python gradio_app.py --server-name 0.0.0.0 --server-port 7860
   ```
 
-## **5. 特徴・強み (Pros)**
+## **6. 特徴・強み (Pros)**
 
 * 絵文字をテキストに挿入するだけという、非常に直感的かつユニークな方法で音声スタイルや感情をコントロールできる。
 * 数秒の音声サンプルから声質を再現するゼロショットのボイスクローニング機能を搭載している。
 * オープンソース（MITライセンス）として公開されており、ローカル環境での推論および独自データでの追加学習（ファインチューニング）が容易である。
 
-## **6. 弱み・注意点 (Cons)**
+## **7. 弱み・注意点 (Cons)**
 
 * 現時点では日本語のテキスト入力にのみ対応している。
 * 漢字の読み上げ精度が同規模の他のTTSモデルと比較して比較的弱いため、複雑な漢字は事前にひらがなやカタカナに変換する必要がある場合がある。
 * 絵文字によるスタイル制御の効果はコンテキストに依存し、常に完全に一貫しているとは限らない。
 
-## **7. 料金プラン**
+## **8. 料金プラン**
 
 | プラン名 | 料金 | 主な特徴 |
 |---------|------|---------|
@@ -130,26 +159,26 @@ relationships:
 * **課金体系**: 完全無料（インフラ費用は利用者負担）
 * **無料トライアル**: なし（Hugging Face Spacesのデモで無料お試し可能）
 
-## **8. 導入実績・事例**
+## **9. 導入実績・事例**
 
 * **導入企業**: 公開事例なし。（2026年リリースのモデルのため、個別のエンタープライズ事例は公開されていない。）
 * **導入事例**: AI研究者や個人開発者を中心に、ローカルTTS環境の構築や、独自のAIアシスタントの音声モジュールとして検証・利用されている。
 * **対象業界**: ソフトウェア開発、エンターテインメント、研究・教育機関。
 
-## **9. サポート体制**
+## **10. サポート体制**
 
 * **ドキュメント**: GitHubのREADME、およびHugging FaceのModel Cardに詳細なセットアップ手順や学習・推論の実行方法が記載されている。
 * **コミュニティ**: GitHubのIssuesおよびHugging FaceのDiscussionsでのコミュニティベースのやり取り。
 * **公式サポート**: オープンソースプロジェクトのため、企業向けの専用公式サポート窓口（SLA付きのチャット・電話対応など）は提供されていない。
 
-## **10. エコシステムと連携**
+## **11. エコシステムと連携**
 
-### **10.1 API・外部サービス連携**
+### **11.1 API・外部サービス連携**
 
 * **API**: 組み込みのGradio Web UIを立ち上げることで、APIエンドポイントを通じた外部からの利用が可能。
 * **外部サービス連携**: Hugging Face Hubとの統合（モデルチェックポイントのダウンロード）、Weights & Biases（W&B）との統合（学習ログのトラッキング）。
 
-### **10.2 技術スタックとの相性**
+### **11.2 技術スタックとの相性**
 
 | 技術スタック | 相性 | メリット・推奨理由 | 懸念点・注意点 |
 |:---|:---:|:---|:---|
@@ -157,19 +186,19 @@ relationships:
 | **PyTorch / CUDA** | ◎ | GPUを利用した高速な学習・推論に最適化されている。 | 環境構築時に適切なCUDAバージョンの指定が必要。 |
 | **Gradio** | ◯ | 標準でUI用スクリプト(`gradio_app.py`)が提供されている。 | 本番環境での大規模運用には別のAPIサーバー構築が必要な場合がある。 |
 
-## **11. セキュリティとコンプライアンス**
+## **12. セキュリティとコンプライアンス**
 
 * **認証**: ツール自体はローカルで動作するため、独自の認証メカニズムは備えていない。Gradio UIを公開する場合はBasic認証などの追加設定が必要。
 * **データ管理**: ユーザーのローカル環境または管理下のサーバーで実行されるため、音声データやテキストデータが意図せず外部に送信されることはない。
 * **準拠規格**: 公式サイトで公開されている特定の認証（SOC2やISO27001など）はない。
 * **Ethical Restrictions (倫理的制限)**: モデルの利用にあたり、「明確な同意なしに個人の声をクローン・模倣しないこと」「誤情報の拡散やディープフェイク生成を目的として利用しないこと」という制限が設けられている。
 
-## **12. 操作性 (UI/UX) と学習コスト**
+## **13. 操作性 (UI/UX) と学習コスト**
 
 * **UI/UX**: 推論用のCLI（`infer.py`）は引数が明確に整理されており使いやすい。また、非エンジニアや簡単なテスト用にGradioベースのWeb UIも用意されており、ブラウザ上から直感的に操作できる。
 * **学習コスト**: PythonやPyTorchの基礎知識があれば、環境構築から推論までは非常にスムーズ。モデルの独自学習（準備スクリプトの実行やマニフェスト作成）に関する手順も詳細にドキュメント化されているため、AIモデル学習の経験者であれば学習コストは低い。
 
-## **13. ベストプラクティス**
+## **14. ベストプラクティス**
 
 * **効果的な活用法 (Modern Practices)**:
   * 感情を込めた音声を生成したい場合、テキスト内の適切な位置に対応する絵文字（例：`EMOJI_ANNOTATIONS.md` に記載のもの）を配置することで、細かいニュアンスを調整する。
@@ -178,7 +207,7 @@ relationships:
   * 難読漢字や一般的な辞書にない固有名詞をそのまま入力すると、誤読が発生しやすいため、前処理としてルビ振り（ひらがな化）のステップを挟まないこと。
   * 他人の声を無断でクローニングリファレンスとして使用すること（倫理的制限に抵触するため）。
 
-## **14. ユーザーの声（レビュー分析）**
+## **15. ユーザーの声（レビュー分析）**
 
 * **調査対象**: GitHubリポジトリ、Hugging Face
 * **総合評価**: 該当なし（G2、Capterra、ITreviewなどのBtoB向けレビューサイトへの登録なし）
@@ -191,34 +220,43 @@ relationships:
 * **特徴的なユースケース**:
   * テキスト生成AI（LLM）の出力テキストに対し、感情分析結果に応じた絵文字を付与し、それをIrodori-TTSに渡すことで動的に感情が変化するエージェント音声の生成。
 
-## **15. 直近半年のアップデート情報**
+## **16. 直近半年のアップデート情報**
 
-* **2026-03**: GitHubリポジトリおよびHugging Faceにて「Irodori-TTS-500M」モデルの公開。
-* **2026-03**: `uv` を用いたパッケージ管理の導入、Gradio UI、CLI推論ツールの整備。
+* **2026-05-31**: 3ブランチ条件付け（テキスト・参照音声・キャプション）に対応した「v3 VoiceDesign」モデルがリリース。
+* **2026-05-26**: Intel XPU PyTorchバックエンドのサポートを追加。
+* **2026-05-19**: AMD ROCm PyTorchバックエンドのサポートを追加。また、ベースモデルを凍結したまま軽量な話者埋め込みを学習・推論できる「Speaker Inversion」機能が追加。
+* **2026-05-16**: WAV保存時のdtypeの安全性を向上 (Make WAV saving dtype-safe)。
+* **2026-05-14**: 動的なLoRA読み込み (dynamic lora loading) 機能をサポート。
+* **2026-05-12**: 「Irodori-TTS-500M-v3」モデルがリリース。RF EulerサンプラーにSway Samplingサポートが追加。
+* **2026-03-31**: キャプション条件付きのVoiceDesignモデルのサポートが追加。
+* **2026-03-26**: PEFT/LoRAファインチューニングのサポートが追加。
+* **2026-03-22**: v2モデルリリース。
+* **2026-03-10**: 「Irodori-TTS-500M」モデルの公開およびツール整備。
 
-(出典: [GitHubリポジトリ](https://github.com/Aratako/Irodori-TTS) など)
+(出典: [製品アップデート情報 (GitHub Releases)](https://github.com/Aratako/Irodori-TTS/releases))
 
-## **16. 類似ツールとの比較**
+## **17. 類似ツールとの比較**
 
-### **16.1 機能比較表 (星取表)**
+### **17.1 機能比較表 (星取表)**
 
 | 機能カテゴリ | 機能項目 | 本ツール (Irodori-TTS) | ElevenLabs | VOICEVOX |
 |:---:|:---|:---:|:---:|:---:|
 | **基本機能** | 音声合成品質 | ◯<br><small>高品質だが漢字読みに課題</small> | ◎<br><small>世界最高峰の自然さ</small> | ◯<br><small>実用的な品質、キャラクター音声中心</small> |
-| **カテゴリ特定** | ボイスクローン | ◯<br><small>ゼロショット対応</small> | ◎<br><small>高速かつ高精度なクローニング</small> | ×<br><small>標準機能としては非提供</small> |
-| **カテゴリ特定** | スタイル制御 | ◎<br><small>独自の絵文字制御</small> | ◯<br><small>プロンプトによる指示</small> | ◯<br><small>UIからの感情・ピッチ調整</small> |
+| **カテゴリ特定** | ボイスクローン | ◯<br><small>ゼロショット対応</small> | ◎<br><small>少量の音声で高精度</small> | ×<br><small>標準機能としては非提供</small> |
+| **カテゴリ特定** | スタイル制御 | ◎<br><small>絵文字・キャプション(VoiceDesign)による制御</small> | ◯<br><small>プロンプトによる指示</small> | ◯<br><small>UIからの感情・ピッチ調整</small> |
+| **マルチモーダル** | 音楽/動画生成 | ×<br><small>非対応</small> | ◎<br><small>音楽(v2)・効果音・動画対応</small> | ×<br><small>非対応</small> |
 | **非機能要件** | 日本語対応 | ◯<br><small>日本語のみ対応</small> | ◯<br><small>多言語対応の一部として</small> | ◎<br><small>日本語特化</small> |
 | **非機能要件** | ローカル実行 | ◎<br><small>OSSで完全にローカル動作可能</small> | ×<br><small>クラウドAPI提供のみ</small> | ◎<br><small>OSSでローカル実行可能</small> |
 
-### **16.2 詳細比較**
+### **17.2 詳細比較**
 
 | ツール名 | 特徴 | 強み | 弱み | 選択肢となるケース |
 |---------|------|------|------|------------------|
-| **本ツール** | 絵文字による感情制御とローカル実行可能なOSS | 無料で使え、ローカルで完結。絵文字によるユニークな制御。 | 漢字の読みに課題。環境構築の知識が必要。 | プライバシーを重視し、ローカルで完全に自律する音声エージェントを開発したい場合。 |
-| **ElevenLabs** | 商用の最高峰AI音声生成プラットフォーム | 圧倒的な音声品質と、多言語対応。 | クラウドベースであり、利用量に応じた従量課金が発生。 | 商用レベルの最高品質のナレーションやボイスクローンが必要で、予算がある場合。 |
+| **本ツール** | 絵文字・キャプションによる感情制御とローカル実行可能なOSS | 無料で使え、ローカルで完結。絵文字やキャプション(VoiceDesign)によるユニークで細やかな制御。 | 漢字の読みに課題。環境構築の知識が必要。 | プライバシーを重視し、ローカルで完全に自律する音声エージェントを開発したい場合。 |
+| **ElevenLabs** | 総合AIメディア生成PF | 圧倒的な音声品質と多機能性(音楽・動画生成など)。APIも充実。 | 従量課金コストの管理が必要。 | 最高品質の音声が必要な場合や、アプリへの組み込みを行う場合。 |
 | **VOICEVOX** | 無料で使える中品質なテキスト読み上げソフトウェア | 日本語特化でGUIが使いやすく、キャラクター音声が豊富。 | ボイスクローン機能がない。商用利用には各キャラクターの規約確認が必要。 | 手軽に動画用のキャラクター音声を付けたい場合。 |
 
-## **17. 総評**
+## **18. 総評**
 
 * **総合的な評価**:
   Irodori-TTSは、Flow Matching技術を用いた高品質な日本語音声生成と、ゼロショットボイスクローニングをオープンソースで実現した意欲的なプロジェクトです。特に入力テキストに絵文字を含めることで直感的に声のスタイルや感情を制御できるアプローチはユニークであり、今後のAIエージェントの表現力を高める上で非常に有用です。現状では漢字の読み上げ精度にやや課題があるものの、無料でローカル実行可能な音声合成エンジンとして高いポテンシャルを秘めています。


### PR DESCRIPTION
Updated the Irodori-TTS report to reflect the latest updates, including v3 models, VoiceDesign, and properly updated ElevenLabs' competitor features in the star chart. Also verified and correctly structured the section numbers up to 18 according to the template.

---
*PR created automatically by Jules for task [2347950232224753674](https://jules.google.com/task/2347950232224753674) started by @aegisfleet*