### PR TITLE
chore: organize category tags (2026-08-09)

### DIFF
--- a/_reports/axios.md
+++ b/_reports/axios.md
@@ -2,7 +2,7 @@
 title: Axios 調査レポート
 tool_name: Axios
 tool_reading: アクシオス
-category: API/仕様管理
+category: Webフレームワーク
 developer: Matt Zabriskie
 official_site: https://axios-http.com/
 date: '2026-03-31'
@@ -11,6 +11,7 @@ tags:
   - JavaScript
   - オープンソース
   - 開発者ツール
+  - API
 description: ブラウザおよびNode.js向けの、Promiseベースの強力なHTTPクライアントライブラリ。
 quick_summary:
   has_free_plan: true


### PR DESCRIPTION
Integrated the 1-off `API/仕様管理` category into `Webフレームワーク` per 2026-08-09 daily category organizing task constraints. Verified relationships remain correct and updated tool tags.

---
*PR created automatically by Jules for task [8624617450771427555](https://jules.google.com/task/8624617450771427555) started by @aegisfleet*