### PR TITLE
Update Oracle Agent Factory Report to Release 26.4

### DIFF
--- a/_reports/oracle-agent-factory.md
+++ b/_reports/oracle-agent-factory.md
@@ -6,7 +6,7 @@ category: エージェントプラットフォーム
 developer: Oracle
 official_site: https://docs.oracle.com/en/database/oracle/agent-factory/
 date: '2026-03-31'
-last_updated: '2026-03-31'
+last_updated: '2026-08-10'
 tags:
   - AI
   - エージェント
@@ -22,7 +22,7 @@ quick_summary:
     - ビジネスユーザー
     - 開発者
     - データアナリスト
-  latest_highlight: Release 25.3でGoogle Drive連携やGeminiモデルサポート、各種新ノード（計算機、Wikipedia検索等）を追加
+  latest_highlight: Release 26.4でDeep Data Research Agent、AI Enrichment、Amazon S3連携、Observability等の新機能を追加
   update_frequency: 中
 evaluation:
   score: 80
@@ -39,13 +39,13 @@ evaluation:
       reason: Oracleエコシステムへの依存度が比較的高く、単独での料金体系が不明瞭
   summary: Oracle製品群を利用中のエンタープライズ企業にとって、安全かつ迅速にAIエージェントを導入できる強力なプラットフォーム。
 links:
-  documentation: https://docs.oracle.com/en/database/oracle/agent-factory/25.3/paias/index.html
+  documentation: https://docs.oracle.com/en/database/oracle/agent-factory/26.4/paias/index.html
 relationships:
   parent: Oracle Database
   children: []
   related_tools:
     - Dify
-    - Flowise
+    - LangChain
 ---
 
 # **Oracle AI Database Private Agent Factory 調査レポート**
@@ -57,7 +57,7 @@ relationships:
 * **開発元**: Oracle
 * **公式サイト**: [https://docs.oracle.com/en/database/oracle/agent-factory/](https://docs.oracle.com/en/database/oracle/agent-factory/)
 * **関連リンク**:
-  * ドキュメント: [Agent Factory User's Guide (Release 25.3)](https://docs.oracle.com/en/database/oracle/agent-factory/25.3/paias/index.html)
+  * ドキュメント: [Agent Factory User's Guide (Release 26.4)](https://docs.oracle.com/en/database/oracle/agent-factory/26.4/paias/index.html)
 * **カテゴリ**: AIエージェント基盤
 * **概要**: ビジネスユーザーとエンジニアの双方が、コードを書くことなくインテリジェントなAIエージェントを迅速に構築、テスト、デプロイできるノーコードプラットフォーム。エンタープライズデータとの安全な連携とマルチエージェントのオーケストレーションを実現します。
 
@@ -67,44 +67,59 @@ relationships:
 * **想定利用者**: ビジネスユーザー、データアナリスト、エンタープライズ開発者。
 * **利用シーン**:
   * SharePointやGoogle Drive内の社内文書に基づいた質疑応答を行うナレッジベースエージェント（Knowledge Agent）の運用
+  * アップロードされたファイル群から情報検索し、引用元を明記した回答を生成するリサーチ用エージェント（Deep Data Research Agent）の活用
   * Oracle Database内の構造化データに自然言語でアクセスし、インサイトやグラフを自動生成するデータ分析エージェント（Data Analysis Agent）の活用
   * 複数の専門エージェントをオーケストレーションした複雑な業務ワークフローの自動化
 
 ## **3. 主要機能**
 
 * **Agent Builder**: ドラッグ＆ドロップの視覚的なインターフェースを用いて、ノード（LLM、データコネクタ、ツールなど）を接続し、ワークフローを構築する機能。
-* **プレビルドエージェント**: 即座に展開可能な「Knowledge Agent」と「Data Analysis Agent」、および再利用可能なエージェントテンプレートを提供。
-* **データソースコネクタ**: Google Drive、SharePoint、Oracle Database (19c以上)、REST API、ファイルシステム、Webサイトなど、社内の多様なデータソースに接続。
+* **プレビルドエージェント**: 即座に展開可能な「Knowledge Agent」「Data Analysis Agent」、およびドキュメント群からの深いリサーチに特化した「Deep Data Research Agent」などのテンプレートを提供。
+* **データソースコネクタ**: Amazon S3、Google Drive、SharePoint、Oracle Database (19c以上)、REST API、ファイルシステム、Webサイトなど、社内の多様なデータソースに接続。
+* **AI Enrichment**: データベースのスキーマ、テーブル、カラムに対してメタデータアノテーションを付与し、AI（Data Analysis Agentなど）がデータベースの構造をより正確に理解できるよう支援する機能。
 * **マルチエージェントオーケストレーション**: マネージャーエージェントが複数の専門的なサブエージェントにタスクを委譲する階層的なエージェントフローの構築が可能。
-* **モデル連携と相互運用性**: OCI GenAI、OpenAI、Google Gemini、Ollama、vLLMなどのLLMおよび埋め込みモデルをサポート。Agent Specでのインポート/エクスポートにより、LangGraphやAutoGenなどへ再利用が可能。
+* **モデル連携と相互運用性**: OCI GenAI、OpenAI、Google Gemini、Ollama、vLLMなどのLLMおよび埋め込みモデルをサポート。Agent Spec形式や暗号化された `.paf` アーカイブによるワークフローのインポート/エクスポートが可能。
 * **MCP (Model Context Protocol) サーバー**: 外部のツールやデータソースをMCPサーバーとして追加・統合する機能をサポート。
+* **Observability（監視とトレース）**: Arize PhoenixやComet Opikと連携し、エージェントの実行トレース、LLM呼び出しのスパン、ツールの実行履歴、レイテンシなどを詳細に監視・分析する機能。
 
-## **4. 開始手順・セットアップ**
+## **4. 動作原理・システム構成**
+
+* **アーキテクチャ**: Oracle Databaseをバックエンドとするセキュアなクライアント・サーバー構成（OCI Marketplaceからのデプロイやオンプレミス環境に対応）。
+* **主要コンポーネントとデータフロー**:
+  * **フロントエンド**: WebブラウザベースのノーコードUI（Agent Builder、Prompt Lab）。
+  * **バックエンド**: エージェントのルーティング、LLMとの通信、データコネクタの管理を行うエンジン。トレースデータは設定されたObservabilityプロバイダー（Arize Phoenix等）にエクスポートされる。
+  * **データベース**: エージェントの設定、ユーザープロンプト、Knowledge Agentのベクトルデータ（Oracle AI Vector Searchを利用）は全てOracle Database内にセキュアに保存される。
+* **特筆すべき要素技術**:
+  * **Oracle Select AI**: データベース内の構造化データに対する自然言語クエリをSQLに変換し、安全に実行・可視化する技術。
+  * **MCP (Model Context Protocol)**: サードパーティのツールやAPIを標準化されたプロトコルで接続し、エージェントの機能を拡張する仕組み。
+
+## **5. 開始手順・セットアップ**
 
 * **前提条件**:
   * LinuxまたはmacOS環境、あるいはOCI (Oracle Cloud Infrastructure) Marketplaceからの展開が可能。
 * **インストール/導入**:
   * OCI Marketplaceからのインストール、またはダウンロードキットを使用してLinux/macOS環境へセットアップする。
 * **初期設定**:
-  * SSO（シングルサインオン）の構成やSMTPの設定を行う。
+  * SSO（シングルサインオン）の構成やSMTP、ネットワークプロキシ（Proxy Settings）の設定を行う。
+  * ログのトレースとパフォーマンス分析を行う場合はObservabilityプロバイダー（Arize PhoenixやComet Opik）のエンドポイントを設定する。
   * 利用するLLM（生成モデルと埋め込みモデル）を設定画面から構成する。
-  * 利用したいデータソース（SharePoint、Oracle Database、Google Driveなど）の接続情報を設定する。
+  * 利用したいデータソース（Amazon S3、SharePoint、Oracle Database、Google Driveなど）の接続情報を設定し、必要に応じてAI Enrichmentのパッケージをデータベースにインストールする。
 * **クイックスタート**:
-  * テンプレートギャラリーから「Knowledge Agent」等のプレビルドエージェントを選択し、アイコンや説明を設定して「Playground」ボタンからすぐに動作確認（チャット）を行うことができる。
+  * テンプレートギャラリーからプレビルドエージェントを選択し、アイコンや説明を設定して「Playground」ボタンからすぐに動作確認（チャット）を行うことができる。
 
-## **5. 特徴・強み (Pros)**
+## **6. 特徴・強み (Pros)**
 
 * **直感的なノーコード開発**: エンジニアリングの背景がなくても、ドラッグ＆ドロップで高度なAIエージェントやワークフローを構築できる。
 * **Oracle Databaseとの強力な統合**: Oracle AI Vector Searchによる正確なグラウンディングや、Select AIを活用したデータベースとの対話（Data Analysis Agent）が標準でシームレスに動作する。
 * **エンタープライズ級のセキュリティとガバナンス**: ロールベースのアクセス制御、SSO対応、プロンプトのガードレール、および応答の組み込み評価機能により、本番環境でも安全に運用できる。
 
-## **6. 弱み・注意点 (Cons)**
+## **7. 弱み・注意点 (Cons)**
 
 * **Oracleエコシステムへの依存**: Oracle DatabaseやOCI環境での利用が前提となる機能が多く、他社クラウドや他社DB中心の環境では利点を最大限に活かしにくい。
 * **SDKの未提供**: 25.3リリース時点では、開発者向けのSDKがサポートされておらず（今後のリリースで対応予定）、外部からの利用はREST API経由のPOSTリクエストに限定される。
 * **料金体系の不透明さ**: 製品単体での明確なSaaS型料金プランが公開されておらず、Oracle DatabaseのライセンスやOCIの契約に基づくため導入コストが把握しづらい。
 
-## **7. 料金プラン**
+## **8. 料金プラン**
 
 公式サイトでは公開されていない。個別の問い合わせが必要。一般的にOracle DatabaseのライセンスまたはOCIの課金体系の一部として提供される形態となっている。
 
@@ -115,26 +130,26 @@ relationships:
 * **課金体系**: 不明（利用インフラ・ライセンスに依存）
 * **無料トライアル**: OCIの無料トライアル枠内での検証が可能かについては要確認。
 
-## **8. 導入実績・事例**
+## **9. 導入実績・事例**
 
 * **導入企業**: 公開事例はまだ少ない。
 * **導入事例**: 主に既存のOracle Databaseエンタープライズ顧客基盤において、社内データ活用や業務自動化の用途で導入が進められている。
 * **対象業界**: 金融、製造、公共機関など、セキュリティ要件が厳しくOracle Databaseをミッションクリティカルに利用している大企業。
 
-## **9. サポート体制**
+## **10. サポート体制**
 
 * **ドキュメント**: Oracle Help Centerにて公式の「Agent Factory User's Guide」などの詳細なドキュメントが提供されている。
 * **コミュニティ**: Oracle LiveLabsを通じて、ハンズオンワークショップが利用可能。
 * **公式サポート**: Oracleの標準的なエンタープライズ向けサポート窓口（My Oracle Support等）を利用。
 
-## **10. エコシステムと連携**
+## **11. エコシステムと連携**
 
-### **10.1 API・外部サービス連携**
+### **11.1 API・外部サービス連携**
 
 * **API**: 構築したエージェントは「Agent API Endpoint URL」として公開され、外部からPOSTリクエストでチャットの実行が可能。
-* **外部サービス連携**: SharePoint, Google Drive, REST API連携機能, MCPサーバー経由でのサードパーティツール連携を標準サポート。
+* **外部サービス連携**: Amazon S3, SharePoint, Google Drive, REST API連携機能, MCPサーバー経由でのサードパーティツール連携、Slack（Webhook Node）、Arize Phoenix / Comet Opik（Observability）を標準サポート。
 
-### **10.2 技術スタックとの相性**
+### **11.2 技術スタックとの相性**
 
 | 技術スタック | 相性 | メリット・推奨理由 | 懸念点・注意点 |
 |:---|:---:|:---|:---|
@@ -142,35 +157,46 @@ relationships:
 | **LangGraph / AutoGen / CrewAI** | ◯ | Agent Specフォーマットでのインポート・エクスポートをサポートし、ワークフローの再利用が可能。 | 完全な双方向の互換性については事前検証が必要 |
 | **外部フロントエンド (React等)** | △ | 公開されたAPIエンドポイントを叩くことで統合可能。 | 専用のSDKが現在未提供のため、認証やセッション管理（CookieやBasic認証）を自前で実装する必要がある |
 
-## **11. セキュリティとコンプライアンス**
+## **12. セキュリティとコンプライアンス**
 
 * **認証**: シングルサインオン (SSO) に対応し、エンタープライズの既存のID管理と統合可能。
-* **データ管理**: Oracle Database内でデータをセキュアに管理。プロンプトガードレール機能により、AIの振る舞いを安全に制限・管理できる。
+* **データ管理**: Oracle Database内でデータをセキュアに管理。プロンプトガードレール機能により、AIの振る舞いを安全に制限・管理できる。ワークフローのエクスポート時は `.paf` アーカイブとしてパスワードによる暗号化保護が行われる。
+* **ネットワークセキュリティ**: Proxy設定を通じて、安全でないHTTP接続の拒否や、プライベートネットワーク（Loopback, Link-local等）への不正なアウトバウンド通信のブロック（SSRF対策）を強制可能。
 * **準拠規格**: Oracle Cloudの厳格なエンタープライズセキュリティ基準およびコンプライアンスに準拠。プライベートサブネットへの配置も可能。
 
-## **12. 操作性 (UI/UX) と学習コスト**
+## **13. 操作性 (UI/UX) と学習コスト**
 
 * **UI/UX**: Agent Builderはドラッグアンドドロップでノードを繋ぐ直感的なUIを備えており、複雑なフローも視覚的に把握しやすい。アイコンピッカーによるエージェントのカスタマイズ機能も搭載されている。
 * **学習コスト**: プログラミング知識が不要なため、ビジネスユーザーでも低い学習コストで使い始めることができる。ただし、複雑な正規表現ノードやMCPサーバーの追加、Select AIのカスタマイズには一定の技術的理解が求められる。
 
-## **13. ベストプラクティス**
+## **14. ベストプラクティス**
 
 * **効果的な活用法 (Modern Practices)**:
   * プレビルドの「Knowledge Agent」や「Data Analysis Agent」をテンプレートとして利用し、スモールスタートでPoCを迅速に行う。
   * 複雑なタスクは1つの巨大なプロンプトで処理するのではなく、役割を分割したサブエージェントを作成し、マネージャーエージェントでオーケストレーションする設計にする。
+  * Observability機能（Arize Phoenix等）を有効化し、LLMの応答やツールの実行履歴を細かくトレースすることで、プロンプトのデバッグやレイテンシの分析を日常的に行う。
+  * チーム間でワークフローを共有する際は、エクスポートされた `.paf` アーカイブとパスワードを安全なチャネルで共有し、不要になった古いアーカイブは破棄する。
 * **陥りやすい罠 (Antipatterns)**:
   * 適切なガードレールやテストを行わずに、強力なData Analysis Agentを本番の業務データに接続してしまうこと。必ずPlaygroundでの十分な検証と、組み込みの評価機能を利用することが推奨される。
 
-## **14. ユーザーの声（レビュー分析）**
+## **15. ユーザーの声（レビュー分析）**
 
 * **調査対象**: G2, Capterra, ITreview
 * **総合評価**: 該当プラットフォームに特化したレビューの登録なし（Oracle Databaseの機能の一部として評価されることが多いため）。
 
 公式サイトの情報に基づく特徴的なユースケースとして、非エンジニアのビジネスユーザーが自部門のSharePointドキュメントを読み込ませた独自のAIアシスタントを数分で立ち上げる、といった迅速な自動化シナリオが想定されている。
 
-## **15. 直近半年のアップデート情報**
+## **16. 直近半年のアップデート情報**
 
-* **2026-03 (Release 25.3)**:
+* **2026-07-31 (Release 26.4)**:
+  * 検索と情報引用に特化した「Deep Data Research Agent」を追加。
+  * スキーマやテーブルのアノテーションを支援する「AI Enrichment」機能を導入。
+  * Arize PhoenixおよびComet Opikを利用したトレース・監視機能（Observability）をサポート。
+  * Amazon S3データソースのサポートを追加。
+  * ワークフローのエクスポート・インポート機能（.pafアーカイブ）を追加。
+  * 新しいノード（Slack Webhook、PL/SQL Executor、Current Date等）を追加。
+  * アウトバウンドトラフィックを制御するためのProxy Settingsを追加。
+* **2026-03-31 (Release 25.3)**:
   * Google Driveデータソースのサポート追加。
   * Geminiの生成モデルおよび埋め込みモデルのサポート追加。
   * Select AIユーティリティとの統合およびSelect AIノードの追加。
@@ -178,28 +204,29 @@ relationships:
   * MCP ServerユーティリティおよびMCP Serverノードの追加。
   * OCI Marketplaceを利用したプライベートサブネットのプライベートVMへのデプロイサポート。
 
-(出典: [What’s New in Release 25.3](https://docs.oracle.com/en/database/oracle/agent-factory/25.3/paias/whats-new.html))
+(出典: [Oracle AI Database Private Agent Factory](https://docs.oracle.com/en/database/oracle/agent-factory/))
 
-## **16. 類似ツールとの比較**
+## **17. 類似ツールとの比較**
 
-### **16.1 機能比較表 (星取表)**
+### **17.1 機能比較表 (星取表)**
 
-| 機能カテゴリ | 機能項目 | 本ツール | Dify | Flowise |
+| 機能カテゴリ | 機能項目 | 本ツール | Dify | LangChain |
 |:---:|:---|:---:|:---:|:---:|
-| **基本機能** | ノーコードワークフロー構築 | ◎<br><small>Agent Builder搭載</small> | ◎<br><small>使いやすいビルダー搭載</small> | ◎<br><small>LangChainベースのビルダー</small> |
-| **カテゴリ特定** | データベースとの対話 | ◎<br><small>Oracle DBとのシームレスな統合</small> | ◯<br><small>標準ノードで可能</small> | ◯<br><small>標準ノードで可能</small> |
-| **カテゴリ特定** | マルチエージェント機能 | ◎<br><small>階層的オーケストレーションをサポート</small> | ◯<br><small>サポート強化中</small> | △<br><small>実装に工夫が必要</small> |
-| **エンタープライズ** | SSO/アクセス制御 | ◎<br><small>標準対応</small> | ◯<br><small>上位プランで対応</small> | △<br><small>基本機能は限定的</small> |
+| **基本機能** | ノーコードUI/ワークフロー | ◎<br><small>Agent Builder搭載</small> | ◎<br><small>洗練されたノーコードビルダー</small> | △<br><small>コード記述が中心</small> |
+| **カテゴリ特定** | データベースとの対話 | ◎<br><small>Oracle DBと緊密統合(AI Enrichment等)</small> | ◯<br><small>各種DB連携可能</small> | ◎<br><small>強力なSQL/Vector DB連携エコシステム</small> |
+| **カテゴリ特定** | マルチエージェント機能 | ◎<br><small>マネージャーエージェントによる階層的処理</small> | ◯<br><small>エージェント連携をサポート</small> | ◎<br><small>LangGraphによる柔軟な制御</small> |
+| **カテゴリ特定** | トレース・監視(Observability) | ◯<br><small>Arize Phoenix / Comet Opikと連携</small> | ◯<br><small>標準のログ・分析機能を内蔵</small> | ◎<br><small>専用プラットフォームLangSmithが強力</small> |
+| **エンタープライズ** | SSO/アクセス制御・ガバナンス | ◎<br><small>Oracle Cloud水準のセキュリティ、標準SSO</small> | ◯<br><small>上位(Ent)プランで対応</small> | △<br><small>基本はOSS、LangSmithはEntプランあり</small> |
 
-### **16.2 詳細比較**
+### **17.2 詳細比較**
 
 | ツール名 | 特徴 | 強み | 弱み | 選択肢となるケース |
 |---------|------|------|------|------------------|
-| **本ツール (Oracle Agent Factory)** | Oracle提供のエンタープライズ向けノーコードAI基盤 | Oracle DBとの緊密な統合、強力なセキュリティとガバナンス | Oracleエコシステムに強く依存、料金が不明瞭 | 既にOracle Databaseを利用しており、セキュアなAIアシスタントを迅速に展開したい場合 |
-| **Dify** | オープンソースのLLMアプリケーション開発プラットフォーム | 直感的なUI、豊富なモデル・ツール連携、オープンソース | 大規模なエンタープライズDB連携には独自実装が必要な場合がある | ベンダーロックインを避けたい場合や、幅広いモデルを柔軟に利用したい場合 |
-| **Flowise** | LangChainベースのオープンソースノーコードUI | LangChainのエコシステムをそのまま視覚的に利用可能 | エンタープライズ向けの権限管理やガバナンス機能が弱い | 開発者がプロトタイプを素早く構築し、LangChainベースの検証を行いたい場合 |
+| **本ツール (Oracle Agent Factory)** | Oracle提供のエンタープライズ向けノーコードAI基盤 | Oracle DBとの緊密な統合、強力なセキュリティとObservability連携 | Oracleエコシステムに強く依存、料金が不明瞭 | 既にOracle Databaseを利用しており、セキュアなAIアシスタントを迅速に展開したい場合 |
+| **Dify** | 直感的なオープンソース開発プラットフォーム | ノーコード/ローコードでの使いやすさと本番環境運用機能の両立 | 大規模なエンタープライズDB連携には独自実装が必要な場合がある | 幅広いモデルを柔軟に利用し、ビジネスユーザー主導で迅速にプロトタイピングを行いたい場合 |
+| **LangChain** | 汎用LLMフレームワークのデファクトスタンダード | 圧倒的なエコシステムの広さ、LangGraphによる複雑な制御とLangSmithによる運用監視 | 学習コストが非常に高い、機能過多になりがち | 開発チームが独自の高度なエージェントロジックや既存システムとの深い統合をコードベースで行う場合 |
 
-## **17. 総評**
+## **18. 総評**
 
 * **総合的な評価**:
   Oracle AI Database Private Agent Factoryは、Oracleエコシステムを活用するエンタープライズ企業にとって、セキュリティ要件を満たしながら迅速にAIエージェントを構築できる非常に強力なプラットフォームです。直感的なUIと強力なデータコネクタにより、エンジニアとビジネスユーザーのコラボレーションを促進します。


### PR DESCRIPTION
Updates the `oracle-agent-factory.md` report to include the latest features from Release 26.4, such as Deep Data Research Agent, AI Enrichment, Amazon S3, and Observability. The comparison table is also updated to include LangChain instead of Flowise. All sections strictly follow the required template and instructions.

---
*PR created automatically by Jules for task [11987390517092307924](https://jules.google.com/task/11987390517092307924) started by @aegisfleet*