### PR TITLE
Integrate category for sakura-editor from テキストエディタ to IDE/エディタ

### DIFF
--- a/_reports/sakura-editor.md
+++ b/_reports/sakura-editor.md
@@ -2,7 +2,7 @@
 title: サクラエディタ 調査レポート
 tool_name: サクラエディタ
 tool_reading: サクラエディタ
-category: テキストエディタ
+category: IDE/エディタ
 developer: Sakura Editor Project
 official_site: https://sakura-editor.github.io/
 date: '2026-08-10'
@@ -11,6 +11,8 @@ tags:
   - テキストエディタ
   - オープンソース
   - Windows
+  - IDE
+  - 開発者ツール
 description: Windows向けの多機能で軽量なオープンソースの日本語テキストエディタ
 quick_summary:
   has_free_plan: true


### PR DESCRIPTION
Integrate the under-populated "テキストエディタ" category (1 item) into the standard "IDE/エディタ" category for the `sakura-editor.md` report.

Added complementary standard tags (`IDE`, `開発者ツール`). Verified relationships and ensured no unwanted modifications (such as `last_updated` date). No updates required for `_data/categories.yml` as `テキストエディタ` was previously listed as undefined.

---
*PR created automatically by Jules for task [6592243878449216804](https://jules.google.com/task/6592243878449216804) started by @aegisfleet*