### PR TITLE
chore: organize categories and tags

### DIFF
--- a/_reports/element.md
+++ b/_reports/element.md
@@ -2,7 +2,7 @@
 title: Element 調査レポート
 tool_name: Element
 tool_reading: エレメント
-category: コミュニケーション
+category: コラボレーション/生産性
 developer: Element Creations Ltd
 official_site: https://element.io/
 date: '2026-08-11'

--- a/_reports/grok-bot.md
+++ b/_reports/grok-bot.md
@@ -2,14 +2,14 @@
 title: Grok Bot 調査レポート
 tool_name: Grok Bot
 tool_reading: グロック ボット
-category: AIエージェント
+category: 自律型AIエージェント
 developer: X.AI LLC
 official_site: https://x.ai/bot
 date: '2026-08-12'
 last_updated: '2026-08-12'
 tags:
-  - AIエージェント
-  - 業務自動化
+  - エージェント
+  - 自動化
   - RPA
 description: 自らのコンピュータを持ち、ユーザーと同じようにツールやアプリを操作して24時間自律的に作業を完了させるAIチームメイト
 quick_summary:

--- a/_reports/kitesurf.md
+++ b/_reports/kitesurf.md
@@ -2,16 +2,16 @@
 title: Kitesurf 調査レポート
 tool_name: Kitesurf
 tool_reading: カイトサーフ
-category: ブラウザ
+category: ブラウザ操作エージェント
 developer: Cloudflare
 official_site: https://kitesurf.cloudflare.app/
 date: '2026-08-11'
 last_updated: '2026-08-11'
 tags:
-  - AIエージェント
+  - エージェント
   - WebAssembly
   - Cloudflare Workers
-  - ブラウザ
+  - 自律型
 description: Cloudflare Workers上のV8アイソレートで動作するAIエージェント向けのステートレスなブラウザエンジン
 quick_summary:
   has_free_plan: true


### PR DESCRIPTION
As per the instructions in `task-organizing-category-tags.md`, I performed the daily category organization:
1. Identified reports with 1-2 categories (element, grok-bot, kitesurf).
2. Merged them into appropriate existing standardized categories.
3. Updated associated tags to align with the standard tag vocabulary (Tier 1-3).
4. Ensured that `last_updated` dates remained unchanged.
5. Ran the yaml lint and relationship check scripts to ensure data consistency.
6. Ran the test suite to ensure no regressions were introduced.

Since the old categories were not originally defined in `_data/categories.yml`, I did not need to modify that file.

---
*PR created automatically by Jules for task [601847054948534032](https://jules.google.com/task/601847054948534032) started by @aegisfleet*