### PR TITLE
chore: organize categories and tags for 2026-08-19

### DIFF
--- a/_reports/codex-pet-share.md
+++ b/_reports/codex-pet-share.md
@@ -2,15 +2,15 @@
 title: Codex Pet Share 調査レポート
 tool_name: Codex Pet Share
 tool_reading: コーデックス ペット シェア
-category: 開発ツール
+category: CLIツール群
 developer: portons
 official_site: https://codex-pets.net/
 date: '2026-08-17'
 last_updated: '2026-08-17'
 tags:
   - オープンソース
+  - 開発者ツール
   - コミュニティ
-  - UI/UX
 description: Codex向けのピクセルペットを共有・閲覧・取得できるセルフホスト可能なWebアプリケーションプラットフォーム
 quick_summary:
   has_free_plan: true

--- a/_reports/ni-collabo-360.md
+++ b/_reports/ni-collabo-360.md
@@ -2,17 +2,17 @@
 title: NI Collabo 360 調査レポート
 tool_name: NI Collabo 360
 tool_reading: エヌアイコラボサンロクマル
-category: グループウェア
+category: コラボレーション/生産性
 developer: 株式会社NIコンサルティング
 official_site: https://www.ni-ware.com/
 date: '2026-08-18'
 last_updated: '2026-08-18'
 tags:
+  - SaaS
+  - クラウド
   - グループウェア
   - ワークフロー
-  - 経費精算
-  - テレワーク支援
-  - クラウド
+  - 勤怠管理
 description: スケジュール、文書管理、社内SNSからワークフロー、経費精算まで36の機能を統合した低価格・高機能な経営改善型グループウェア
 quick_summary:
   has_free_plan: false


### PR DESCRIPTION
This PR organizes the categories and tags for `codex-pet-share.md` and `ni-collabo-360.md` based on the daily category organizing task.

*   `codex-pet-share`: Changed category from `開発ツール` to `CLIツール群` and updated tags.
*   `ni-collabo-360`: Changed category from `グループウェア` to `コラボレーション/生産性` and updated tags.
*   Neither `開発ツール` nor `グループウェア` are in `_data/categories.yml`, so no deletion is required there.
*   Verified that no implicit data in other parts of the markdown were modified.
*   Confirmed no relationships were broken.

---
*PR created automatically by Jules for task [14867770885686397811](https://jules.google.com/task/14867770885686397811) started by @aegisfleet*