### PR TITLE
カテゴリ整理: キュレーションリストの統合

### DIFF
--- a/_reports/awesome-gemma.md
+++ b/_reports/awesome-gemma.md
@@ -2,7 +2,7 @@
 title: Awesome Gemma 調査レポート
 tool_name: Awesome Gemma
 tool_reading: オーサム ジェンマ
-category: キュレーションリスト
+category: ナレッジベース/Wiki
 developer: Google DeepMind
 official_site: https://github.com/google-gemma/awesome-gemma
 date: '2026-08-21'
@@ -11,7 +11,7 @@ tags:
   - Gemma
   - オープンソース
   - LLM
-  - リソース集
+  - Wiki
 description: Google DeepMindのオープンモデルGemmaファミリに関する軽量かつ最先端のリソースをまとめた公式キュレーションリスト
 quick_summary:
   has_free_plan: true


### PR DESCRIPTION
This PR consolidates the 1-2 count category `キュレーションリスト` into `ナレッジベース/Wiki` per the integration rules. The `レンタルサービス` category is kept unchanged as it is a specialized genre. `_data/categories.yml` is correctly synced. 

- `awesome-gemma.md` category updated to `ナレッジベース/Wiki`
- `awesome-gemma.md` tag updated to `Wiki`
- `キュレーションリスト` removed from `_data/categories.yml`
- Tests and integrity checks ran successfully

---
*PR created automatically by Jules for task [11697473131090188218](https://jules.google.com/task/11697473131090188218) started by @aegisfleet*